### PR TITLE
Introduce field-function 

### DIFF
--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2043,9 +2043,12 @@ def get_field_definition(defn):
     # proto = { "arg{}".format(i+1) : get_field_definition(d) for i,d in enumerate(defn) }
     proto = collections.OrderedDict([("arg{}".format(i+1), get_field_definition(d))
                                      for i,d in enumerate(defn)])
+    default = tuple([field.default for field in proto.values() if field.has_default])
+    set_default = len(default) == len(proto) # calling type modifies proto so compare it beforehand
+    
     proto['Meta'] = type("Meta", (object,), {"is_tuple" : True, "_anon" : True})
     ct = type("ClormAnonTuple", (Predicate,), proto)
-    return ct.Field()
+    return ct.Field(default) if set_default else ct.Field()
 
 
 #------------------------------------------------------------------------------

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -27,7 +27,7 @@ import re
 import uuid
 
 from . import noclingo
-from typing import Any, Iterator, List, Sequence, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Callable, Iterator, List, Sequence, Tuple, Type, TypeVar, Union, overload
 
 __all__ = [
     'ClormError',
@@ -1222,26 +1222,32 @@ class BaseField(object, metaclass=_AbstractBaseFieldMeta):
 # https://github.com/python/cpython/blob/0b58bac3e7877d722bdbd3c38913dba2cb212f13/Lib/dataclasses.py#L346
 # https://github.com/python/typeshed/blob/e434b23741a5e3f2ea899ccfb0ef2a15f168ebf1/stubs/dataclasses/dataclasses.pyi#L45
 
-@overload
-def field(basefield: Union[Type[BaseField], Sequence[Type[BaseField]]]) -> Any: ...
+_FieldDefinition = Union[Type[BaseField], Tuple['_FieldDefinition']]
 
 @overload
-def field(basefield: Union[Type[BaseField], Sequence[Type[BaseField]]],*, default: _T) -> _T: ...
+def field(basefield: _FieldDefinition) -> Any: ...
 
-def field(basefield,*, default=MISSING):
-    if isinstance(basefield, Sequence):
+@overload
+def field(basefield: _FieldDefinition,*, default: _T) -> _T: ...
+
+@overload
+def field(basefield: _FieldDefinition,*, default_factory: Callable[[], _T]) -> _T: ...
+
+def field(basefield,*, default=MISSING, default_factory=MISSING):
+    if default is not MISSING and default_factory is not MISSING:
+        raise ValueError('can not specify both default and default_factory')
+    if isinstance(basefield, Tuple):
         if default is not MISSING:
-            if not isinstance(default, Sequence) or len(basefield) != len(default):
-                raise ValueError((f"Default {default} must have the same length as {basefield}"))
-            ret: Tuple[Any,...] = ()
-            for i, bf in enumerate(basefield):
-                ret += (field(bf,default=default[i]),)
-            return ret
+            return _create_complex_term(basefield, default)
+        elif default_factory is not MISSING:
+            return _create_complex_term(basefield, default_factory)
         return basefield
 
     if issubclass(basefield, BaseField):
         if default is not MISSING:
             return basefield(default)
+        elif default_factory is not MISSING:
+            return basefield(default_factory)
         return basefield
 
     raise TypeError(f"{basefield} can just be of Type '{BaseField}' or '{Sequence}'")
@@ -2034,6 +2040,9 @@ def get_field_definition(defn):
     # Expecting a tuple and treat it as a recursive definition
     if not isinstance(defn, tuple): raise TypeError(errmsg.format(defn))
 
+    return _create_complex_term(defn)
+
+def _create_complex_term(defn, default_value=MISSING) -> BaseField:
     # NOTE: I was using a dict rather than OrderedDict which just happened to
     # work. Apparently, in Python 3.6 this was an implmentation detail and
     # Python 3.7 it is a language specification (see:
@@ -2041,11 +2050,16 @@ def get_field_definition(defn):
     # However, since Clorm is meant to be Python 3.5 compatible change this to
     # use an OrderedDict.
     # proto = { "arg{}".format(i+1) : get_field_definition(d) for i,d in enumerate(defn) }
-    proto = collections.OrderedDict([("arg{}".format(i+1), get_field_definition(d))
+    proto = collections.OrderedDict([(f"arg{i+1}", get_field_definition(d))
                                      for i,d in enumerate(defn)])
-    default = tuple([field.default for field in proto.values() if field.has_default])
-    set_default = len(default) == len(proto) # calling type modifies proto so compare it beforehand
-    
+    if default_value is not MISSING:
+        default = default_value
+        set_default = True
+    else:
+        default = tuple([field.default for field in proto.values() if field.has_default])
+        set_default = len(default) == len(proto) # calling type modifies proto so compare it beforehand
+        if not set_default and default:
+            raise ValueError((f"Default {default_value} must have the same length as {defn}"))
     proto['Meta'] = type("Meta", (object,), {"is_tuple" : True, "_anon" : True})
     ct = type("ClormAnonTuple", (Predicate,), proto)
     return ct.Field(default) if set_default else ct.Field()

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -970,13 +970,30 @@ class PredicateTestCase(unittest.TestCase):
         # None is a legit value and can therefore be set as a default value.
         class DumbField(StringField):
             pytocl = lambda d: "silly" if d  is None else "ok"
-            cltopy = lambda s: None if d == "silly" else "ok"
+            cltopy = lambda s: None if s == "silly" else "ok"
         class Q(Predicate):
             first = DumbField(default=None)
 
         q = Q()
         raw_q = Function("q",[String("silly")])
         self.assertEqual(q.raw, raw_q)
+
+    #--------------------------------------------------------------------------
+    # Test default value for anonymous tuple
+    # --------------------------------------------------------------------------
+    def test_predicate_anonymous_field_with_default(self):
+
+        class P(Predicate):
+            first = IntegerField
+            tuple_ = (IntegerField(2),StringField("42"))
+
+        p = P(first=15,tuple_=(1,"2"))
+        raw_p = Function("p",[Number(15), Function("",[Number(1),String("2")])])
+        self.assertEqual(p.raw, raw_p)
+
+        p = P(first=15)
+        raw_p = Function("p",[Number(15), Function("",[Number(2),String("42")])])
+        self.assertEqual(p.raw, raw_p)
 
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a function called `field` which will help to better incorporate with typecheckers like mypy or pyright.
Right now if we define a predicate
```python
class P(Predicate):
    a = IntegerField
    b = StringField

p1 = P(a=3, b="4")
```
typecheckers think that `p1.a` is an IntegerField but actually it is an `int`. If you want to specify this, you have to annotate the attribute with  a typehint
```python
class P(Predicate):
    a: int = IntegerField
    b: str = StringField
```
But then we get an type error because we want to assign an `IntegerField` to an attribute `a` of type `int`.
To resolve that error we use a function `field` where we pass the Field-Class as an argument and the function returns `Any` (or the type of the default value if one is given). Because `Any` can be assigned to an `int` we  don't get an error anymore.

```python
class P(Predicate):
    a: int = field(IntegerField, default=42)
    b: str = field(StringField, default="42")
```


In essence `field` is just a wrapper-function with proper typehints which returns the given Field-Class. `dataclasses` uses the same concept ([link](https://github.com/python/cpython/blob/0b58bac3e7877d722bdbd3c38913dba2cb212f13/Lib/dataclasses.py#L346))