### PR TITLE
Infer fielddefinition from annotations

### DIFF
--- a/clorm/orm/__init__.py
+++ b/clorm/orm/__init__.py
@@ -8,6 +8,7 @@ from .factbase import *
 from .query import *
 from .symbols_facts import *
 from .atsyntax import *
+from .types import *
 
 __all__ = [
     'ClormError',
@@ -69,6 +70,11 @@ __all__ = [
     'control_add_facts',
     'symbolic_atoms_to_facts',
     'parse_fact_string',
-    'parse_fact_files'
+    'parse_fact_files',
+    "ConstantStr",
+    "HeadList",
+    "HeadListReversed",
+    "TailList",
+    "TailListReversed"
     ]
 

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2449,6 +2449,10 @@ def _infer_field_definition(type_: Type) -> Optional[BaseField]:
     if type_ is ConstantStr:
         return ConstantField
     if inspect.isclass(type_):
+        if issubclass(type_, enum.Enum):
+            # if type_ just inherits from Enum is IntegerField, otherwise find appropriate Field
+            field = IntegerField if len(type_.__bases__) == 1 else _infer_field_definition(type_.__bases__[0])
+            return define_enum_field(field, type_)
         if issubclass(type_, int):
             return IntegerField
         elif issubclass(type_, str):

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -27,6 +27,8 @@ import typing
 import re
 import uuid
 
+from clorm.orm.types import ConstantStr
+
 from . import noclingo
 from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Type, TypeVar, Union, overload
 
@@ -2444,6 +2446,8 @@ def _is_bad_predicate_inner_class_declaration(name,obj):
 
 # infer fielddefinition based on a given type
 def _infer_field_definition(type_: Type) -> Optional[BaseField]:
+    if type_ is ConstantStr:
+        return ConstantField
     if inspect.isclass(type_):
         if issubclass(type_, int):
             return IntegerField

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -27,7 +27,7 @@ import typing
 import re
 import uuid
 
-from clorm.orm.types import ConstantStr
+from clorm.orm.types import ConstantStr, HeadList, HeadListReversed, TailList, TailListReversed
 
 from . import noclingo
 from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Type, TypeVar, Union, overload
@@ -2451,6 +2451,14 @@ def _infer_field_definition(type_: Type) -> Optional[BaseField]:
 
     if type_ is ConstantStr:
         return ConstantField
+    if origin is HeadList:
+        return define_nested_list_field(_infer_field_definition(args[0]))
+    if origin is HeadListReversed:
+        return define_nested_list_field(_infer_field_definition(args[0]),reverse=True)
+    if origin is TailList:
+        return define_nested_list_field(_infer_field_definition(args[0]),headlist=False)
+    if origin is TailListReversed:
+        return define_nested_list_field(_infer_field_definition(args[0]),headlist=False, reverse=True)
     if inspect.isclass(type_):
         if issubclass(type_, enum.Enum):
             # if type_ just inherits from Enum is IntegerField, otherwise find appropriate Field

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -10,6 +10,7 @@
 
 #import logging
 #import os
+import datetime
 import io
 import abc
 import contextlib
@@ -2478,6 +2479,9 @@ def _infer_field_definition(type_: Type) -> Optional[BaseField]:
         return StringField
     if issubclass(type_, Predicate):
         return type_.Field
+    if issubclass(type_, datetime.date):
+        from clorm.lib.date import DateField # import here because of circular imports
+        return DateField
     return None
 
 # build the metadata for the Predicate - NOTE: this funtion returns a

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2482,6 +2482,9 @@ def _infer_field_definition(type_: Type) -> Optional[BaseField]:
     if issubclass(type_, datetime.date):
         from clorm.lib.date import DateField # import here because of circular imports
         return DateField
+    if issubclass(type_, datetime.time):
+        from clorm.lib.timeslot import TimeField # import here because of circular imports
+        return TimeField
     return None
 
 # build the metadata for the Predicate - NOTE: this funtion returns a

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2485,6 +2485,8 @@ def _infer_field_definition(type_: Type) -> Optional[BaseField]:
     if issubclass(type_, datetime.time):
         from clorm.lib.timeslot import TimeField # import here because of circular imports
         return TimeField
+    if issubclass(type_, Raw):
+        return RawField
     return None
 
 # build the metadata for the Predicate - NOTE: this funtion returns a

--- a/clorm/orm/types.py
+++ b/clorm/orm/types.py
@@ -12,6 +12,7 @@ else:
 _T = TypeVar('_T')
 
 if TYPE_CHECKING:
+    # perhaps renaming to something like Head(First)Tuple(Reversed), Tail(First)Tuple(Reversed)
     HeadList = Tuple[_T, ...]
     HeadListReversed = Tuple[_T, ...]
     TailList = Tuple[_T, ...]

--- a/clorm/orm/types.py
+++ b/clorm/orm/types.py
@@ -1,0 +1,10 @@
+"""contains clorm specific types"""
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    ConstantStr = str
+else:
+    class ConstantStr(str):
+        pass

--- a/clorm/orm/types.py
+++ b/clorm/orm/types.py
@@ -1,10 +1,27 @@
 """contains clorm specific types"""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, Tuple, TypeVar
 
 
 if TYPE_CHECKING:
     ConstantStr = str
 else:
     class ConstantStr(str):
+        pass
+
+_T = TypeVar('_T')
+
+if TYPE_CHECKING:
+    HeadList = Tuple[_T, ...]
+    HeadListReversed = Tuple[_T, ...]
+    TailList = Tuple[_T, ...]
+    TailListReversed = Tuple[_T, ...]
+else:
+    class HeadList(Generic[_T]):
+        pass
+    class HeadListReversed(Generic[_T]):
+        pass
+    class TailList(Generic[_T]):
+        pass
+    class TailListReversed(Generic[_T]):
         pass

--- a/clorm/orm/types.py
+++ b/clorm/orm/types.py
@@ -2,6 +2,13 @@
 
 from typing import TYPE_CHECKING, Generic, Tuple, TypeVar
 
+__all__ = [
+    "ConstantStr",
+    "HeadList",
+    "HeadListReversed",
+    "TailList",
+    "TailListReversed",
+]
 
 if TYPE_CHECKING:
     ConstantStr = str

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1395,7 +1395,13 @@ class PredicateTestCase(unittest.TestCase):
             c = '((((),("1",2)),("2",3)),("3",4))'
             d = '((((),"3"),"2"),"1")'
             self.assertEqual(str(p7), f"p7({a},{b},{c},{d})")
-            
+        
+        class P8(Predicate):
+            a: datetime.date
+
+        with self.subTest("date-object"):
+            p8 = P8(datetime.datetime.strptime("2022-01-11","%Y-%m-%d"))
+            self.assertEquals(p8.a,datetime.datetime(2022,1,11))
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -16,7 +16,7 @@ import operator
 import enum
 import collections.abc as cabc
 
-from clorm.orm.types import ConstantStr
+from clorm.orm.types import ConstantStr, HeadList, HeadListReversed, TailList, TailListReversed
 from .support import check_errmsg
 import pickle
 
@@ -1378,6 +1378,24 @@ class PredicateTestCase(unittest.TestCase):
             self.assertEqual(str(p6_2), "p6((7,8))")
             self.assertEqual(str(p61_2), "p61(((\"1\",2),(\"3\",4)))")
 
+        class P7(Predicate):
+            a: HeadList[int]
+            b: HeadListReversed[str]
+            c: TailList[Tuple[str, int]]
+            d: TailListReversed[str]
+
+        with self.subTest("nested lists"):
+            p7 = P7(a=(1,2,3),
+                    b=("1","2","3"),
+                    c=(("1",2),("2",3),("3",4)),
+                    d=("1", "2", "3")
+                    )
+            a = '(1,(2,(3,())))'
+            b = '("3",("2",("1",())))'
+            c = '((((),("1",2)),("2",3)),("3",4))'
+            d = '((((),"3"),"2"),"1")'
+            self.assertEqual(str(p7), f"p7({a},{b},{c},{d})")
+            
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -15,6 +15,8 @@ import datetime
 import operator
 import enum
 import collections.abc as cabc
+
+from clorm.orm.types import ConstantStr
 from .support import check_errmsg
 import pickle
 
@@ -1331,6 +1333,15 @@ class PredicateTestCase(unittest.TestCase):
             self.assertEquals(str(p3_int), "p3(2)")
             self.assertEquals(str(p3_P), "p3(p(3,\"4\"))")
             self.assertEquals(str(p3_tuple), "p3((42,43))")
+
+        class P4(Predicate):
+            a: ConstantStr
+
+        with self.subTest():
+            self.assertTrue(isinstance(P4.a.meta.field, ConstantField))
+            p4 = P4("asdf")
+            self.assertEquals(str(p4), "p4(asdf)")
+
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1400,8 +1400,15 @@ class PredicateTestCase(unittest.TestCase):
             a: datetime.date
 
         with self.subTest("date-object"):
-            p8 = P8(datetime.datetime.strptime("2022-01-11","%Y-%m-%d"))
-            self.assertEquals(p8.a,datetime.datetime(2022,1,11))
+            p8 = P8(datetime.date(2022,1,11))
+            self.assertEquals(str(p8),"p8(\"2022-01-11\")")
+
+        class P9(Predicate):
+            a: datetime.time
+
+        with self.subTest("date-object"):
+            p9 = P9(datetime.time(17,12))
+            self.assertEquals(str(p9),"p9(\"17:12\")")
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1342,6 +1342,28 @@ class PredicateTestCase(unittest.TestCase):
             p4 = P4("asdf")
             self.assertEquals(str(p4), "p4(asdf)")
 
+        class EnumStr(str,enum.Enum):
+            A="a"
+        class EnumInt(int,enum.Enum):
+            B=1
+        class EnumConstStr(ConstantStr,enum.Enum):
+            C="c"
+        class EnumRaw(enum.Enum):
+            C=42
+
+        class P5(Predicate):
+            a: EnumStr
+            b: EnumInt
+            c: EnumConstStr
+            d: EnumRaw
+
+        with self.subTest():
+            p5 = P5(a=EnumStr.A, b= EnumInt.B, c=EnumConstStr.C, d=EnumRaw.C)
+            self.assertTrue(isinstance(P5.a.meta.field, StringField))
+            self.assertTrue(isinstance(P5.b.meta.field, IntegerField))
+            self.assertTrue(isinstance(P5.c.meta.field, ConstantField))
+            self.assertTrue(isinstance(P5.d.meta.field, IntegerField))
+            self.assertEquals(str(p5), "p5(\"a\",1,c,42)")
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -16,7 +16,6 @@ import operator
 import enum
 import collections.abc as cabc
 
-from clorm.orm.types import ConstantStr, HeadList, HeadListReversed, TailList, TailListReversed
 from .support import check_errmsg
 import pickle
 
@@ -28,7 +27,8 @@ from clorm import \
     define_flat_list_field, define_nested_list_field, define_enum_field, \
     simple_predicate, path, hashable_path, alias, \
     not_, and_, or_, cross, in_, notin_, \
-    SymbolMode, set_symbol_mode, get_symbol_mode, symbols
+    SymbolMode, set_symbol_mode, get_symbol_mode, symbols, \
+    ConstantStr, HeadList, HeadListReversed, TailList, TailListReversed
 
 # Implementation imports
 from clorm.orm.core import dealiased_path, field, get_field_definition, PredicatePath, \

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1323,7 +1323,7 @@ class PredicateTestCase(unittest.TestCase):
         class P3(Predicate):
             a: Union[str, int, P, Tuple[int, int]]
 
-        with self.subTest():
+        with self.subTest("union as annotation"):
             self.assertTrue(isinstance(P3.a.meta.field, BaseField))
             p3_str = P3("1")
             p3_int = P3(2)
@@ -1337,7 +1337,7 @@ class PredicateTestCase(unittest.TestCase):
         class P4(Predicate):
             a: ConstantStr
 
-        with self.subTest():
+        with self.subTest("str which should be handled as a Constant"):
             self.assertTrue(isinstance(P4.a.meta.field, ConstantField))
             p4 = P4("asdf")
             self.assertEquals(str(p4), "p4(asdf)")
@@ -1357,13 +1357,27 @@ class PredicateTestCase(unittest.TestCase):
             c: EnumConstStr
             d: EnumRaw
 
-        with self.subTest():
+        with self.subTest("different variants of enum as annotation"):
             p5 = P5(a=EnumStr.A, b= EnumInt.B, c=EnumConstStr.C, d=EnumRaw.C)
             self.assertTrue(isinstance(P5.a.meta.field, StringField))
             self.assertTrue(isinstance(P5.b.meta.field, IntegerField))
             self.assertTrue(isinstance(P5.c.meta.field, ConstantField))
             self.assertTrue(isinstance(P5.d.meta.field, IntegerField))
             self.assertEquals(str(p5), "p5(\"a\",1,c,42)")
+
+        class P6(Predicate):
+            a: Tuple[int,...]
+        class P61(Predicate):
+            a: Tuple[Tuple[str,int],...]
+
+        with self.subTest("Tuple with arbitrary length as annotation"):
+            p6_4 = P6(a=(1,2,3,4))
+            p6_2 = P6(a=(7,8))
+            p61_2 = P61(a=(("1",2),("3",4)))
+            self.assertEqual(str(p6_4), "p6((1,2,3,4))")
+            self.assertEqual(str(p6_2), "p6((7,8))")
+            self.assertEqual(str(p61_2), "p61(((\"1\",2),(\"3\",4)))")
+
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 
 import inspect
-from typing import Type
+from typing import Tuple
 import unittest
 import datetime
 import operator
@@ -1292,18 +1292,31 @@ class PredicateTestCase(unittest.TestCase):
             b: str
             c: P
 
-        with self.subTest():
+        with self.subTest("one with and one without annotation"):
             p = P(3,"2")
             self.assertEquals(str(p),'p(3,"2")')
             self.assertEquals(p.a, 3)
             self.assertEquals(p.b, "2")
 
-        with self.subTest():
+        with self.subTest("all with annotations + Predicate"):
             p = P1(3,"2",P(4,"4"))
             self.assertEquals(p.a,3)
             self.assertEquals(p.b,"2")
             self.assertEquals(p.c.a,4)
             self.assertEquals(p.c.b,"4")
+
+        class P2(Predicate):
+            a: Tuple[int,Tuple[str, int]]
+
+        with self.subTest("nested tuples as annotations"):
+            self.assertTrue(issubclass(type(P2.meta["a"].defn), BaseField))
+            p = P2((3,("4", 2)))
+            self.assertEquals(p.a[0], 3)
+            self.assertEquals(p.a.arg1, 3)
+            self.assertEquals(p.a[1][0], "4")
+            self.assertEquals(p.a.arg2.arg1, "4")
+            self.assertEquals(p.a[1][1], 2)
+            self.assertEquals(p.a.arg2.arg2, 2)
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1410,6 +1410,13 @@ class PredicateTestCase(unittest.TestCase):
             p9 = P9(datetime.time(17,12))
             self.assertEquals(str(p9),"p9(\"17:12\")")
 
+        class P10(Predicate):
+            a: Raw
+
+        with self.subTest("raw symbol annotations"):
+            p10 = P10(Raw(Function("test",[String("1")])))
+            self.assertEqual(str(p10), "p10(test(\"1\"))")
+
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):
             class P(Predicate):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 
 import inspect
-from typing import Tuple
+from typing import Tuple, Union
 import unittest
 import datetime
 import operator
@@ -1317,6 +1317,20 @@ class PredicateTestCase(unittest.TestCase):
             self.assertEquals(p.a.arg2.arg1, "4")
             self.assertEquals(p.a[1][1], 2)
             self.assertEquals(p.a.arg2.arg2, 2)
+
+        class P3(Predicate):
+            a: Union[str, int, P, Tuple[int, int]]
+
+        with self.subTest():
+            self.assertTrue(isinstance(P3.a.meta.field, BaseField))
+            p3_str = P3("1")
+            p3_int = P3(2)
+            p3_P = P3(P(3,"4"))
+            p3_tuple = P3((42,43))
+            self.assertEquals(str(p3_str), "p3(\"1\")")
+            self.assertEquals(str(p3_int), "p3(2)")
+            self.assertEquals(str(p3_P), "p3(p(3,\"4\"))")
+            self.assertEquals(str(p3_tuple), "p3((42,43))")
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1279,6 +1279,43 @@ class PredicateTestCase(unittest.TestCase):
         e = Empty()
         self.assertFalse(e)
 
+    #--------------------------------------------------------------------------
+    # Test to infer FieldDefinition based on given annotation
+    # --------------------------------------------------------------------------
+    def test_predicates_with_annotated_fields(self):
+        class P(Predicate):
+            a: int = IntegerField
+            b = StringField
+
+        class P1(Predicate):
+            a: int
+            b: str
+            c: P
+
+        with self.subTest():
+            p = P(3,"2")
+            self.assertEquals(str(p),'p(3,"2")')
+            self.assertEquals(p.a, 3)
+            self.assertEquals(p.b, "2")
+
+        with self.subTest():
+            p = P1(3,"2",P(4,"4"))
+            self.assertEquals(p.a,3)
+            self.assertEquals(p.b,"2")
+            self.assertEquals(p.c.a,4)
+            self.assertEquals(p.c.b,"4")
+
+    def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
+        with self.assertRaises(TypeError, msg="order of fields can't be determined"):
+            class P(Predicate):
+                a = IntegerField
+                b: str
+
+    def test_predicate_cant_infer_field_from_annotation(self):
+        with self.assertRaises(TypeError):
+            class P(Predicate):
+                a: int = IntegerField
+                b: float
 
     #--------------------------------------------------------------------------
     # As part of the get_field_definition function to flexibly deal with tuples


### PR DESCRIPTION
This PR adds the functionality to infer the required Field-Definition (`IntegerField`, `StringField`, `Predicate.Field`, etc...) based on a given annotation instead of assigning the Field explicitly.

Some Examples:
```python
class P(Predicate):
    a: int # a=IntegerField
    b: str # b=StringField

class P1(Predicate):
    a: Tuple[int, Tuple[str, int]] # a=(IntegerField, (StringField, IntegerField))
    b: Tuple[int, ...] # b=define_flat_list_field(IntegerField)
    c: P # c=P.Field
    d: Union[int, P] # d=combine_fields([IntegerField,P.Field])
```

This new functionality brings several advantages:
- for the most basic structures (which will make sense using it in clingo) we don't need to use clorm's Field-Definitions. This means people who are familiar with python's NamedTuple or dataclass should have no problem defining predicates
- it makes it obsolete to use the `field`-Function if we want to work with annotations (in case a typechecker is enabled)
- typecheckers are happier and it's even more pythonic ;-)

If someone doesn't like annotations or a annotation will not give the expected structure, it's still possible to use Field-Definitions directly. Additionally if both (annotations and Field-Definition) are given, the Field-Definition has always the higher priority.
