### PR TITLE
Type annotations clorm control

### DIFF
--- a/clorm/clingo.py
+++ b/clorm/clingo.py
@@ -44,7 +44,7 @@ __version__ = oclingo.__version__
 # ------------------------------------------------------------------------------
 
 
-def _build_unifier(unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]] = None) -> Optional[SymbolPredicateUnifier]:
+def _build_unifier(unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]]) -> Optional[SymbolPredicateUnifier]:
     if unifier is None:
         return None
     if isinstance(unifier, SymbolPredicateUnifier):
@@ -78,7 +78,7 @@ class ModelOverride(object):
 
     '''
     if TYPE_CHECKING:
-        _wrapped: ClassVar[OModel]  # will be set through init_wrapper
+        _wrapped: OModel  # will be set through init_wrapper
 
     def __init__(self, model: OModel, unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]] = None) -> None:
         self._unifier = _build_unifier(unifier)
@@ -180,7 +180,7 @@ class SolveHandleOverride(object):
 
     '''
     if TYPE_CHECKING:
-        _wrapped: ClassVar[OSolveHandle]  # will be set through init_wrapper
+        _wrapped: OSolveHandle  # will be set through init_wrapper
 
     def __init__(self, handle: OSolveHandle, unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]] = None) -> None:
         init_wrapper(self, wrapped_=handle)
@@ -283,7 +283,7 @@ class ControlOverride(object):
 
     '''
     if TYPE_CHECKING:
-        _wrapped: ClassVar[OControl]  # will be set through init_wrapper
+        _wrapped: OControl  # will be set through init_wrapper
 
     @overload
     def __init__(self, arguments: Sequence[str] = [],
@@ -451,9 +451,7 @@ class ControlOverride(object):
         if len(args) > len(posnargs):
             raise TypeError(("solve() takes {} positional arguments but {}"
                              "were given").format(len(posnargs), len(args)))
-        nkwargs = {}
-        for idx, arg in enumerate(args):
-            nkwargs[posnargs[idx]] = arg
+        nkwargs = {posnargs[idx]: arg for idx, arg in enumerate(args)}
 
         for k, v in kwargs.items():
             if k not in validargs:

--- a/clorm/clingo.py
+++ b/clorm/clingo.py
@@ -14,6 +14,7 @@ import functools
 import itertools
 from collections.abc import Iterable, Iterator, Generator
 from abc import ABCMeta
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union, overload
 from .orm import *
 from .util.wrapper import WrapperMetaClass, init_wrapper, make_class_wrapper
 
@@ -289,8 +290,25 @@ class ControlOverride(object):
     parameter.
 
     '''
+    @overload
+    def __init__(self, arguments: Sequence[str] = [],
+                 logger: Optional[Logger] = None, message_limit: int = 20) -> None: ...
 
-    def __init__(self, *args, **kwargs):
+    @overload
+    def __init__(self, control_: Any) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *args: Any,
+        unifier: Union[List[Predicate], SymbolPredicateUnifier],
+        **kwargs: Any
+    ) -> None: ...
+
+    @overload
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._unifier = None
         if "unifier" in kwargs: self._unifier = _build_unifier(kwargs["unifier"])
 
@@ -475,7 +493,13 @@ class ControlOverride(object):
         return getattr(self._wrapped,attr)
 
 
-Control = make_class_wrapper(OControl, ControlOverride)
+_clorm_control = make_class_wrapper(OControl, ControlOverride)
+if TYPE_CHECKING:
+    class Control(_clorm_control, OControl):  # type: ignore
+        pass
+else:
+    Control = _clorm_control
+
 
 #------------------------------------------------------------------------------
 # This is probably bad practice... Modify the original clingo docstrings so that

--- a/clorm/clingo.py
+++ b/clorm/clingo.py
@@ -177,37 +177,6 @@ else:
 # ------------------------------------------------------------------------------
 
 
-class SolveHandleGenerator(Generator[Model, None, None]):
-    def __init__(self, gen: Iterator[OModel], unifier: Any) -> None:
-        self._gen = gen
-        self._unifier = unifier
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        model = next(self._gen)
-        if self._unifier:
-            return Model(model, unifier=self._unifier)
-        else:
-            return Model(model)
-
-    # TODO throw, send, close, del will raise an error when called...
-
-    def throw(self, typ, val=None, tb=None):
-        self._gen.throw(typ, val, tb)
-
-    def send(self, value):
-        self._gen.send(value)
-
-    def close(self):
-        self._gen.close()
-
-    def __del__(self):
-        if oclingo.__version__ >= "5.5.0":
-            self._gen.__del__()
-
-
 class SolveHandleOverride(object):
 #class SolveHandle(OSolveHandle, metaclass=WrapperMetaClass):
     '''Handle for solve calls.
@@ -237,7 +206,8 @@ class SolveHandleOverride(object):
     # ------------------------------------------------------------------------------
 
     def __iter__(self):
-        return SolveHandleGenerator(iter(self.solvehandle_), self._unifier)
+        for model in self.solvehandle_:
+            yield Model(model, unifier=self._unifier)
 
     def __enter__(self):
         self.solvehandle_.__enter__()

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2883,7 +2883,7 @@ class Predicate(object, metaclass=_PredicateMeta):
 
     # Get the underlying clingo.Symbol object
     @property
-    def raw(self):
+    def raw(self) -> clingo.Symbol:
         """Returns the underlying clingo.Symbol object"""
         if self._raw is None: self.symbol
         if isinstance(self._raw, noclingo.Symbol):

--- a/clorm/orm/symbols_facts.py
+++ b/clorm/orm/symbols_facts.py
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 import itertools
-from typing import Any, Union
+from typing import Any, Iterable, Union
 from collections import abc
 
 import clingo
@@ -249,7 +249,7 @@ def unify(unifier,symbols,ordered=False):
 
 if clingo.__version__ >= "5.5.0":
 
-    def control_add_facts(ctrl, facts):
+    def control_add_facts(ctrl: clingo.Control, facts: Iterable[Union[Predicate, clingo.Symbol]]) -> None:
         with ctrl.backend() as bknd:
             for f in facts:
                 raw=f.raw if isinstance(f,Predicate) else f
@@ -258,7 +258,7 @@ if clingo.__version__ >= "5.5.0":
 else:
     import clingo.ast as ast
 
-    def control_add_facts(ctrl, facts):
+    def control_add_facts(ctrl: clingo.Control, facts: Iterable[Union[Predicate, clingo.Symbol]]) -> None:
         with ctrl.builder() as bldr:
             line=1
             for f in facts:
@@ -528,7 +528,7 @@ def parse_fact_files(files,unifier,*,factbase=None,
 # A pure-python fact parser that uses Lark
 #------------------------------------------------------------------------------
 
-from .lark_fact_parser import Lark_StandAlone, Transformer, VisitError, LarkError, UnexpectedInput
+from .lark_fact_parser import Lark_StandAlone, Symbol, Transformer, VisitError, LarkError, UnexpectedInput
 
 class _END:
     pass

--- a/clorm/orm/symbols_facts.py
+++ b/clorm/orm/symbols_facts.py
@@ -528,7 +528,7 @@ def parse_fact_files(files,unifier,*,factbase=None,
 # A pure-python fact parser that uses Lark
 #------------------------------------------------------------------------------
 
-from .lark_fact_parser import Lark_StandAlone, Symbol, Transformer, VisitError, LarkError, UnexpectedInput
+from .lark_fact_parser import Lark_StandAlone, Transformer, VisitError, LarkError, UnexpectedInput
 
 class _END:
     pass

--- a/clorm/util/wrapper.py
+++ b/clorm/util/wrapper.py
@@ -24,7 +24,7 @@ https://code.activestate.com/recipes/496741-object-proxying/
 
 import functools
 import inspect
-from typing import Optional, Type, TypeVar, Union, overload
+from typing import Any, Optional, Type, TypeVar, Union, overload
 
 _T = TypeVar("_T", bound=object)
 
@@ -54,7 +54,7 @@ def _check_wrapper_object(wrapper,strict=False):
                          "{}").format(wrapper._wrapped,WrappedType))
 
 # Constructor for every Predicate sub-class
-def init_wrapper(wrapper, *args, **kwargs):
+def init_wrapper(wrapper: Any, *args: Any, **kwargs: Any) -> None:
     Wrapped = wrapper._wrapped_cls
     if "wrapped_" in kwargs:
         if len(args) != 0 and len(kwargs) != 1:

--- a/clorm/util/wrapper.py
+++ b/clorm/util/wrapper.py
@@ -24,6 +24,9 @@ https://code.activestate.com/recipes/496741-object-proxying/
 
 import functools
 import inspect
+from typing import Optional, Type, TypeVar, Union, overload
+
+_T = TypeVar("_T", bound=object)
 
 # ------------------------------------------------------------------------------
 # Make proxy member functions and properties
@@ -105,7 +108,16 @@ class WrapperMetaClass(type):
 # overriding any function/property that is common to both).
 # ------------------------------------------------------------------------------
 
-def make_class_wrapper(inputclass, override=None):
+
+@overload
+def make_class_wrapper(inputclass: Type[object]) -> Type[object]: ...
+
+
+@overload
+def make_class_wrapper(inputclass: Type[object], override: Type[_T]) -> Type[_T]: ...
+
+
+def make_class_wrapper(inputclass: Type[object], override: Optional[Type[_T]] = None) -> Type[Union[object, _T]]:
     def getattrdoc(cls, key):
         if not cls: return None
         try:


### PR DESCRIPTION
This PR
1. adds type annotations to methods and classes in clorm.clingo
2. defines classes for Control, Model and SolveHandle each inheriting from two classes
    + clorm's ControlOverride, ModelOverride and SolveHandleOverride
    + clingo's Control, Model and SolveHandle
    
    This definitions is just active during type-checking, so when python is executed still the wrapper is used.
With this approach we can tell type-checkers/linter that the dynamically created class (wrapper) has methods from clorm's class as well as clingo's implementation. Check the pictures below: `load` and `ground` from clingo.Control as well as `add_facts` from ControlOverride are known methods of `clorm.Control` (highlighted yellow whereas the unkown methods are white)
The user also gets intellisense while typing

| New | Old |
| -----  | ------ |
| ![grafik](https://user-images.githubusercontent.com/72799603/154566670-3ace05d0-ab8d-4115-9f2f-175eff18e3a0.png) | ![grafik](https://user-images.githubusercontent.com/72799603/154567537-aa7de13c-499e-4f2c-96b9-115b36e8c261.png) |
| ![grafik](https://user-images.githubusercontent.com/72799603/154568920-a9fb8d6e-e93f-4d8c-a1a6-3d9061530adb.png) | |


