### PR TITLE
Autocomplete for Predicate.__init__  via `dataclass_transform`

### DIFF
--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -134,6 +134,22 @@ class _classproperty(object):
     def __get__(self, instance, owner):
         return self.getter(owner)
 
+# ------------------------------------------------------------------------------
+# PEP681 https://www.python.org/dev/peps/pep-0681/
+# https://github.com/microsoft/pyright/blob/main/specs/dataclass_transforms.md
+# tells a static type checker that the decorated function or metaclass performs runtime "magic"
+# that transforms a class, endowing it dataclass-like behaviors
+# ------------------------------------------------------------------------------
+
+def __dataclass_transform__(
+    *,
+    eq_default: bool = False,
+    order_default: bool = False,
+    kw_only_default: bool = False,
+    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
+) -> Callable[[_T], _T]:
+    return lambda a: a
+
 #------------------------------------------------------------------------------
 # A descriptor for late initialisation of a read-only value. Helpful for delayed
 # initialisation in metaclasses where an object needs to be created in the
@@ -1291,7 +1307,7 @@ def field(basefield: _FieldDefinition,*, default: _T) -> _T: ...
 @overload
 def field(basefield: _FieldDefinition,*, default_factory: Callable[[], _T]) -> _T: ...
 
-def field(basefield,*, default=MISSING, default_factory=MISSING):
+def field(basefield: _FieldDefinition,*, default: Any=MISSING, default_factory: Any=MISSING) -> Any:
     if default is not MISSING and default_factory is not MISSING:
         raise ValueError('can not specify both default and default_factory')
     if isinstance(basefield, Tuple):
@@ -2713,6 +2729,7 @@ def _define_field_for_predicate(cls) -> Type[BaseField]:
 #------------------------------------------------------------------------------
 # A Metaclass for the Predicate base class
 #------------------------------------------------------------------------------
+@__dataclass_transform__(field_descriptors=(field,))
 class _PredicateMeta(type):
 
     #--------------------------------------------------------------------------

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -1307,7 +1307,7 @@ def field(basefield: _FieldDefinition,*, default: _T) -> _T: ...
 @overload
 def field(basefield: _FieldDefinition,*, default_factory: Callable[[], _T]) -> _T: ...
 
-def field(basefield: _FieldDefinition,*, default: Any=MISSING, default_factory: Any=MISSING) -> Any:
+def field(basefield: _FieldDefinition,*, default: Any=MISSING, default_factory: Any=MISSING, kw_only: bool=False) -> Any:
     if default is not MISSING and default_factory is not MISSING:
         raise ValueError('can not specify both default and default_factory')
     if isinstance(basefield, Tuple):
@@ -2845,6 +2845,10 @@ class Predicate(object, metaclass=_PredicateMeta):
          - named parameters corresponding to the field names.
 
     """
+    # sign and raw are specified here to be recognized from __dataclass_transform__
+    # they will be overriden later
+    sign: bool = field(IntegerField, default=True, kw_only=True)
+    raw: clingo.Symbol = field(IntegerField, default=MISSING, kw_only=True)
     if typing.TYPE_CHECKING:
         # populated by the metaclass, defined here to help IDEs only
         _meta: typing.ClassVar[PredicateDefn]

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2845,10 +2845,10 @@ class Predicate(object, metaclass=_PredicateMeta):
          - named parameters corresponding to the field names.
 
     """
-    # sign and raw are specified here to be recognized from __dataclass_transform__
-    # they will be overriden later
+    # sign is specified here to be recognized from __dataclass_transform__
+    # will be overriden by metaclass
     sign: bool = field(IntegerField, default=True, kw_only=True)
-    raw: clingo.Symbol = field(IntegerField, default=MISSING, kw_only=True)
+
     if typing.TYPE_CHECKING:
         # populated by the metaclass, defined here to help IDEs only
         _meta: typing.ClassVar[PredicateDefn]


### PR DESCRIPTION
This adds autocomplete for fields when creating a new instance of a predicate.

![grafik](https://user-images.githubusercontent.com/72799603/155899164-c646fb84-10cd-4289-a638-91a1bc1936f3.png)
![grafik](https://user-images.githubusercontent.com/72799603/155899178-41f6167e-77d4-4215-aeb6-d1fea2c2b8ba.png)


closes #80