### PR TITLE
Cleanup noclingo

### DIFF
--- a/clorm/orm/noclingo.py
+++ b/clorm/orm/noclingo.py
@@ -56,7 +56,7 @@ import clingo
 import typing
 
 from clingo import SymbolType, Symbol
-from typing import Sequence, Union, Any
+from typing import Optional, Sequence, Tuple, Union, Any, cast
 
 __all__ = [
     'SymbolType',
@@ -83,13 +83,13 @@ __all__ = [
 
 CLORM_NOCLINGO_DEFAULT = 'False'
 
-def _get_CLORM_NOCLINGO():
-    tmp = os.environ.get('CLORM_NOCLINGO', CLORM_NOCLINGO_DEFAULT).lower()
-    if tmp in ('0', 'false', 'no', 'disable'):
-        return False
-    return True
 
-ENABLE_NOCLINGO=_get_CLORM_NOCLINGO()
+def _get_CLORM_NOCLINGO() -> bool:
+    tmp = os.environ.get('CLORM_NOCLINGO', CLORM_NOCLINGO_DEFAULT).lower()
+    return tmp not in ('0', 'false', 'no', 'disable')
+
+
+ENABLE_NOCLINGO = _get_CLORM_NOCLINGO()
 
 # --------------------------------------------------------------------------------
 # Note: the ordering between symbols is manually determined to match clingo 5.5
@@ -102,6 +102,7 @@ _SYMBOLTYPE_OID = {
     SymbolType.String: 4,
     SymbolType.Supremum: 5
 }
+
 
 class NoSymbol(object):
     """A noclingo replacement for clingo.Symbol.
@@ -120,14 +121,14 @@ class NoSymbol(object):
     Symbol objects to be released.
     """
 
-    __slots__=("_stype","_args","_value","_sign","_hash")
+    __slots__ = ("_stype", "_args", "_value", "_sign", "_hash")
 
-    def __init__(self, stype: SymbolType, value: Any=None, args: Sequence[Any]=[],sign: bool=True):
+    def __init__(self, stype: SymbolType, value: Any = None, args: Sequence['NoSymbol'] = [], sign: bool = True):
         if not isinstance(stype, SymbolType):
             raise TypeError("{} is not a SymbolType".format(stype))
         self._stype = stype
-        self._args = None
-        self._value = None
+        self._args: Tuple[NoSymbol, ...] = tuple([])
+        self._value: Optional[Union[int, str]] = None
         self._sign = None
         if stype == SymbolType.Infimum:
             self._hash = hash(0)
@@ -148,7 +149,7 @@ class NoSymbol(object):
             self._sign = bool(sign)
             self._value = str(value)
             self._args = tuple(args)
-            self._hash = hash((self._value,self._args,self._sign))
+            self._hash = hash((self._value, self._args, self._sign))
 
             if not self._value and not self._sign:
                 raise ValueError("Tuple symbol cannot have a negative sign")
@@ -156,41 +157,41 @@ class NoSymbol(object):
             raise ValueError("Unknown SymbolType {}".format(stype))
 
     @property
-    def name(self):
+    def name(self) -> str:
         if self._stype != SymbolType.Function:
             raise RuntimeError()
-        return self._value
+        return cast(str, self._value)
 
     @property
-    def arguments(self):
+    def arguments(self) -> Tuple['NoSymbol', ...]:
         if self._stype != SymbolType.Function:
             raise RuntimeError()
         return self._args
 
     @property
-    def string(self):
+    def string(self) -> str:
         if self._stype != SymbolType.String:
             raise RuntimeError()
-        return self._value
+        return cast(str, self._value)
 
     @property
-    def number(self):
+    def number(self) -> int:
         if self._stype != SymbolType.Number:
             raise RuntimeError()
-        return self._value
+        return cast(int, self._value)
 
     @property
     def type(self):
         return self._stype
 
     @property
-    def positive(self):
+    def positive(self) -> bool:
         if self._stype != SymbolType.Function:
             raise RuntimeError()
-        return self._sign
+        return cast(bool, self._sign)
 
     @property
-    def negative(self):
+    def negative(self) -> bool:
         if self._stype != SymbolType.Function:
             raise RuntimeError()
         return not self._sign
@@ -198,7 +199,7 @@ class NoSymbol(object):
     def __hash__(self):
         return self._hash
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """Overloaded boolean operator."""
         if not isinstance(other, self.__class__) and not isinstance(other, Symbol):
             return NotImplemented
@@ -220,9 +221,9 @@ class NoSymbol(object):
             return False
         if len(self.arguments) != len(other.arguments):
             return False
-        return self.arguments, tuple(other.arguments)
+        return self.arguments == tuple(other.arguments)
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> bool:
         """Overloaded boolean operator."""
         if not isinstance(other, self.__class__) and not isinstance(other, Symbol):
             return NotImplemented
@@ -242,14 +243,14 @@ class NoSymbol(object):
             return False
         return self.arguments > tuple(other.arguments)
 
-
-    def __le__(self, other):
+    def __le__(self, other: object) -> bool:
         """Overloaded boolean operator."""
         result = self.__gt__(other)
-        if result is NotImplemented: return NotImplemented
+        if result is NotImplemented:
+            return NotImplemented
         return not result
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         """Overloaded boolean operator."""
         if not isinstance(other, self.__class__) and not isinstance(other, Symbol):
             return NotImplemented
@@ -269,19 +270,22 @@ class NoSymbol(object):
             return True
         return self.arguments < tuple(other.arguments)
 
-    def __ge__(self, other):
+    def __ge__(self, other: object) -> bool:
         """Overloaded boolean operator."""
         result = self.__lt__(other)
-        if result is NotImplemented: return NotImplemented
+        if result is NotImplemented:
+            return NotImplemented
         return not result
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self._stype == SymbolType.Number:
             return f"{self._value}"
         if self._stype == SymbolType.String:
             return f'"{self._value}"'
-        if self._stype == SymbolType.Infimum: return "#inf"
-        if self._stype == SymbolType.Supremum: return "#sup"
+        if self._stype == SymbolType.Infimum:
+            return "#inf"
+        if self._stype == SymbolType.Supremum:
+            return "#sup"
 
         # SymbolType.Function - Note: tuples have special cases: empty tuple
         # "()" and a singleton "(a, )"
@@ -295,83 +299,91 @@ class NoSymbol(object):
         # A singleton tuple
         return "({},)".format(str(self._args[0]))
 
-    def __repr__(self):
-        return __str__()
-        if self._stype == SymbolType.Infimum:
-            return "Infimum"
-        if self._stype == SymbolType.Supremum:
-            return "Supremum"
-        if self._stype == SymbolType.Number:
-            return f"Number({self.number!r})"
-        if self._stype == SymbolType.String:
-            return f"String({self.string!r})"
-        assert self._stype == SymbolType.Function
-        return f"Function({self.name!r}, {self.arguments!r}, {self.positive!r})"
+    def __repr__(self) -> str:
+        return self.__str__()
 
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 # helper functions to create objects
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
+
 
 AnySymbol = Union[Symbol, NoSymbol]
 
-def NoFunction(name: str, arguments: Sequence[Symbol] = [], positive: bool=True) -> AnySymbol:
+
+def NoFunction(name: str, arguments: Sequence[NoSymbol] = [], positive: bool = True) -> NoSymbol:
     return NoSymbol(SymbolType.Function, name, arguments, positive)
 
-def NoString(string: str) -> AnySymbol:
-    return NoSymbol(SymbolType.String,string)
 
-def NoNumber(number: int) -> AnySymbol:
-    return NoSymbol(SymbolType.Number,number)
+def NoString(string: str) -> NoSymbol:
+    return NoSymbol(SymbolType.String, string)
 
-def NoTuple_(arguments: Sequence[Symbol]) -> AnySymbol:
-    return NoSymbol(SymbolType.Function,"", arguments)
+
+def NoNumber(number: int) -> NoSymbol:
+    return NoSymbol(SymbolType.Number, number)
+
+
+def NoTuple_(arguments: Sequence[NoSymbol]) -> NoSymbol:
+    return NoSymbol(SymbolType.Function, "", arguments)
+
 
 NoInfimum = NoSymbol(SymbolType.Infimum)
 
 NoSupremum = NoSymbol(SymbolType.Supremum)
 
 
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 # Functions to convert between clingo.Symbol and noclingo.Symbol
 # --------------------------------------------------------------------------------
 
-def clingo_to_noclingo(clsym):
-    if isinstance(clsym, NoSymbol): return clsym
-    if clsym.type == clingo.SymbolType.Infimum: return NoInfimum
-    elif clsym.type == clingo.SymbolType.Supremum: return NoSupremum
-    elif clsym.type == clingo.SymbolType.Number: return NoNumber(clsym.number)
-    elif clsym.type == clingo.SymbolType.String: return NoString(clsym.string)
+def clingo_to_noclingo(clsym: Symbol) -> NoSymbol:
+    if isinstance(clsym, NoSymbol):
+        return clsym
+    if clsym.type == clingo.SymbolType.Infimum:
+        return NoInfimum
+    elif clsym.type == clingo.SymbolType.Supremum:
+        return NoSupremum
+    elif clsym.type == clingo.SymbolType.Number:
+        return NoNumber(clsym.number)
+    elif clsym.type == clingo.SymbolType.String:
+        return NoString(clsym.string)
     elif clsym.type != clingo.SymbolType.Function:
         raise TypeError(("Symbol '{}' ({}) is not of type clingo.SymbolType."
-                         "Function").format(clsym,type(clsym)))
+                         "Function").format(clsym, type(clsym)))
 
     return NoFunction(clsym.name,
-                      (clingo_to_noclingo(t) for t in clsym.arguments),
+                      tuple(clingo_to_noclingo(t) for t in clsym.arguments),
                       clsym.positive)
 
 
-def noclingo_to_clingo(nclsym):
-    if isinstance(nclsym, clingo.Symbol): return nclsym
-    if nclsym.type == SymbolType.Infimum: return clingo.Infimum
-    elif nclsym.type == SymbolType.Supremum: return clingo.Supremum
-    elif nclsym.type == SymbolType.Number: return clingo.Number(nclsym.number)
-    elif nclsym.type == SymbolType.String: return clingo.String(nclsym.string)
+def noclingo_to_clingo(nclsym: NoSymbol) -> Symbol:
+    if isinstance(nclsym, clingo.Symbol):
+        return nclsym
+    if nclsym.type == SymbolType.Infimum:
+        return clingo.Infimum
+    elif nclsym.type == SymbolType.Supremum:
+        return clingo.Supremum
+    elif nclsym.type == SymbolType.Number:
+        return clingo.Number(nclsym.number)
+    elif nclsym.type == SymbolType.String:
+        return clingo.String(nclsym.string)
     elif nclsym.type != SymbolType.Function:
         raise TypeError(("Symbol '{}' ({}) is not of type noclingo.SymbolType."
-                         "Function").format(nclsym,type(nclsym)))
+                         "Function").format(nclsym, type(nclsym)))
 
     return clingo.Function(nclsym.name,
-                    tuple(noclingo_to_clingo(t) for t in nclsym.arguments),
-                    nclsym.positive)
+                           tuple(noclingo_to_clingo(t) for t in nclsym.arguments),
+                           nclsym.positive)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # A mechanism to group together the symbol generator functions for clingo or
 # noclingo.
 # ------------------------------------------------------------------------------
 
 class SymbolMode(enum.IntEnum):
-    CLINGO=0
-    NOCLINGO=1
+    CLINGO = 0
+    NOCLINGO = 1
+
 
 # ------------------------------------------------------------------------------
 # Globals to will change depending on clingo or noclingo mode

--- a/clorm/orm/noclingo.py
+++ b/clorm/orm/noclingo.py
@@ -51,7 +51,6 @@ will raise an exception.
 # --------------------------------------------------------------------------------
 
 import os
-import functools
 import enum
 import clingo
 import typing
@@ -388,91 +387,86 @@ _mode = SymbolMode.CLINGO
 
 
 # ------------------------------------------------------------------------------
-
-# ------------------------------------------------------------------------------
-
-# Forward function signature declaration
-def Function(name: str, arguments: Sequence[Symbol] = [], positive: bool=True) -> AnySymbol:
-    pass
-def String(string: str) -> AnySymbol:
-    pass
-def Number(number: int) -> AnySymbol:
-    pass
-def Tuple_(arguments: Sequence[Symbol] = []) -> AnySymbol:
-    pass
-
-# ------------------------------------------------------------------------------
 # Common functions that are valid even if NOCLINGO is disabled
 # ------------------------------------------------------------------------------
 
 def get_symbol_mode() -> SymbolMode:
     return _mode
 
+
 def get_Infimum() -> AnySymbol:
     return _infimum
+
 
 def get_Supremum() -> AnySymbol:
     return _supremum
 
 
 if typing.TYPE_CHECKING:
-    def Function(name: str, arguments: Sequence[Symbol] = [], positive: bool=True) -> AnySymbol:
-        pass
+    def set_symbol_mode(sm: SymbolMode) -> None:
+        ...
+
+    def Function(name: str, arguments: Sequence[Symbol] = [], positive: bool = True) -> AnySymbol:
+        ...
+
     def String(string: str) -> AnySymbol:
-        pass
+        ...
+
     def Number(number: int) -> AnySymbol:
-        pass
+        ...
+
     def Tuple_(arguments: Sequence[Symbol]) -> AnySymbol:
-        pass
-
-# NoClingo introduces some overhead, with the indirection when creating
-# symbols. But if we don't need NoClingo then we can avoid this indirection
-if ENABLE_NOCLINGO:
-
-    def set_symbol_mode(sm: SymbolMode):
-        global _infimum, _supremum, _string, _number, _tuple_, _function, _mode
-        _mode = sm
-        if sm == SymbolMode.CLINGO:
-            _infimum = clingo.Infimum
-            _supremum = clingo.Supremum
-            _string = clingo.String
-            _number = clingo.Number
-            _tuple_ = clingo.Tuple_
-            _function = clingo.Function
-        else:
-            _infimum = NoInfimum
-            _supremum = NoSupremum
-            _string = NoString
-            _number = NoNumber
-            _tuple_ = NoTuple_
-            _function = NoFunction
-
-    def Function(name: str, arguments: Sequence[Symbol] = [], positive: bool=True) -> Symbol:
-        return _function(name, arguments, positive)
-
-    def String(string: str) -> Symbol:
-        return _string(string)
-
-    def Number(number: int) -> Symbol:
-        return _number(number)
-
-    # clingo.Tuple_() doesn't have default parameters so follow the same here
-    def Tuple_(arguments: Sequence[Symbol]) -> Symbol:
-        return _tuple_(arguments)
+        ...
 
 else:
+    # NoClingo introduces some overhead, with the indirection when creating
+    # symbols. But if we don't need NoClingo then we can avoid this indirection
+    if ENABLE_NOCLINGO:
 
-    def set_symbol_mode(sm: SymbolMode):
-        raise RuntimeError("NOCLINGO mode is disabled.")
+        def set_symbol_mode(sm: SymbolMode):
+            global _infimum, _supremum, _string, _number, _tuple_, _function, _mode
+            _mode = sm
+            if sm == SymbolMode.CLINGO:
+                _infimum = clingo.Infimum
+                _supremum = clingo.Supremum
+                _string = clingo.String
+                _number = clingo.Number
+                _tuple_ = clingo.Tuple_
+                _function = clingo.Function
+            else:
+                _infimum = NoInfimum
+                _supremum = NoSupremum
+                _string = NoString
+                _number = NoNumber
+                _tuple_ = NoTuple_
+                _function = NoFunction
 
-    Function=clingo.Function
-    String=clingo.String
-    Number=clingo.Number
-    Tuple_=clingo.Tuple_
+        def Function(name: str, arguments: Sequence[Symbol] = [], positive: bool = True) -> Symbol:
+            return _function(name, arguments, positive)
+
+        def String(string: str) -> Symbol:
+            return _string(string)
+
+        def Number(number: int) -> Symbol:
+            return _number(number)
+
+        # clingo.Tuple_() doesn't have default parameters so follow the same here
+        def Tuple_(arguments: Sequence[Symbol]) -> Symbol:
+            return _tuple_(arguments)
+
+    else:
+
+        def set_symbol_mode(sm: SymbolMode):
+            raise RuntimeError("NOCLINGO mode is disabled.")
+
+        Function = clingo.Function
+        String = clingo.String
+        Number = clingo.Number
+        Tuple_ = clingo.Tuple_
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # main
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 if __name__ == "__main__":
     raise RuntimeError('Cannot run modules')


### PR DESCRIPTION
With this PR typechecking for functions `Function, String, Number, Tuple_ and set_symbol_mode` should now be handled properly. Before always the last function definition was used by the type-checker (the ones when noclingo is disabled). This leads to a wrong return type annotation (`Symbol` instead of `AnySymbol`) and when calling set_symbol_mode the type-checker mentioned unreachable code after the function call (due to raising a RuntimeError).

PR also adds typehints to noclingo.py