### PR TITLE
Add support for bool

### DIFF
--- a/clorm/lib/boolean.py
+++ b/clorm/lib/boolean.py
@@ -1,0 +1,69 @@
+'''A library of Python bool functions and terms for use within an ASP
+   program. 
+
+'''
+
+
+from typing import Any
+from clorm.orm.core import AnySymbol, BaseField, IntegerField
+from clorm.orm.noclingo import Number
+
+
+BOOL_FALSE = {0, '0', 'off', 'f', 'false', 'n', 'no'}
+BOOL_TRUE = {1, '1', 'on', 't', 'true', 'y', 'yes'}
+
+def bool_validator(v: Any) -> bool:
+    if v is True or v is False:
+        return v
+    if isinstance(v, str):
+        v = v.lower()
+    if v in BOOL_TRUE:
+        return True
+    if v in BOOL_FALSE:
+        return False
+    raise TypeError(f"value '{v}' could not be parsed to a boolean")
+
+class BooleanField(BaseField):
+    """A field to convert between a Clingo.Number/String object and a Python bool.
+    
+    Conversion failes if the value/clingo.Symbol is not one of the following:
+    - a valid boolean ('True' or 'False')
+    - the integers '0' or '1'
+    - a 'str' which when converted to lower case in one of '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'
+    """
+
+    def cltopy(symbol: AnySymbol) -> bool:
+        try:
+            return bool_validator(symbol.number)
+        except (AttributeError, RuntimeError):
+            pass
+        try:
+            return bool_validator(symbol.string)
+        except (AttributeError, RuntimeError):
+            pass
+        raise TypeError(("Object '{}' ({}) is not a Number/String "
+                         "Symbol").format(symbol,type(symbol)))
+
+    def pytocl(v):
+        val = int(bool_validator(v))
+        return Number(val)
+
+
+class StrictBooleanField(IntegerField):
+    """A field to convert between a Clingo.Number object and a Python bool
+    - Clingo.Number(0) will be converted to 'False'
+    - Clingo.Number(1) will be converted to 'True'
+
+    For everything else the conversion fails
+    """
+    def cltopy(symbol) -> bool:
+        if symbol == 1:
+            return True
+        if symbol == 0:
+            return False
+        raise TypeError("value must be either '0' or '1'")
+
+    def pytocl(v):
+        if isinstance(v, bool):
+            return int(v)
+        raise TypeError("value is not a valid boolean")

--- a/clorm/orm/__init__.py
+++ b/clorm/orm/__init__.py
@@ -79,6 +79,7 @@ __all__ = [
     'parse_fact_string',
     'parse_fact_files',
     "ConstantStr",
+    "StrictBool",
     "HeadList",
     "HeadListReversed",
     "TailList",

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -1512,6 +1512,49 @@ class SimpleField(BaseField):
             return String(value)
 
 #------------------------------------------------------------------------------
+# A BooleanField
+#------------------------------------------------------------------------------
+
+BOOL_FALSE = {0, '0', 'off', 'f', 'false', 'n', 'no'}
+BOOL_TRUE = {1, '1', 'on', 't', 'true', 'y', 'yes'}
+
+def bool_validator(v: Any) -> bool:
+    if v is True or v is False:
+        return v
+    if isinstance(v, str):
+        v = v.lower()
+    if v in BOOL_TRUE:
+        return True
+    if v in BOOL_FALSE:
+        return False
+    raise TypeError(f"value '{v}' could not be parsed to a boolean")
+
+class BooleanField(BaseField):
+    """A field to convert between a Clingo.Number/String object and a Python bool.
+    
+    Conversion failes if the value/clingo.Symbol is not one of the following:
+    - a valid boolean ('True' or 'False')
+    - the integers '0' or '1'
+    - a 'str' which when converted to lower case in one of '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'
+    """
+
+    def cltopy(symbol: AnySymbol) -> bool:
+        try:
+            return bool_validator(symbol.number)
+        except (AttributeError, RuntimeError):
+            pass
+        try:
+            return bool_validator(symbol.string)
+        except (AttributeError, RuntimeError):
+            pass
+        raise TypeError(("Object '{}' ({}) is not a Number/String "
+                         "Symbol").format(symbol,type(symbol)))
+
+    def pytocl(v):
+        val = int(bool_validator(v))
+        return Number(val)
+
+#------------------------------------------------------------------------------
 # refine_field is a function that creates a sub-class of a BaseField (or BaseField
 # sub-class). It restricts the set of allowable values based on a functor or an
 # explicit set of values.

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -1512,70 +1512,6 @@ class SimpleField(BaseField):
             return String(value)
 
 #------------------------------------------------------------------------------
-# A BooleanField
-#------------------------------------------------------------------------------
-
-BOOL_FALSE = {0, '0', 'off', 'f', 'false', 'n', 'no'}
-BOOL_TRUE = {1, '1', 'on', 't', 'true', 'y', 'yes'}
-
-def bool_validator(v: Any) -> bool:
-    if v is True or v is False:
-        return v
-    if isinstance(v, str):
-        v = v.lower()
-    if v in BOOL_TRUE:
-        return True
-    if v in BOOL_FALSE:
-        return False
-    raise TypeError(f"value '{v}' could not be parsed to a boolean")
-
-class BooleanField(BaseField):
-    """A field to convert between a Clingo.Number/String object and a Python bool.
-    
-    Conversion failes if the value/clingo.Symbol is not one of the following:
-    - a valid boolean ('True' or 'False')
-    - the integers '0' or '1'
-    - a 'str' which when converted to lower case in one of '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'
-    """
-
-    def cltopy(symbol: AnySymbol) -> bool:
-        try:
-            return bool_validator(symbol.number)
-        except (AttributeError, RuntimeError):
-            pass
-        try:
-            return bool_validator(symbol.string)
-        except (AttributeError, RuntimeError):
-            pass
-        raise TypeError(("Object '{}' ({}) is not a Number/String "
-                         "Symbol").format(symbol,type(symbol)))
-
-    def pytocl(v):
-        val = int(bool_validator(v))
-        return Number(val)
-
-
-class StrictBooleanField(IntegerField):
-    """A field to convert between a Clingo.Number object and a Python bool
-    - Clingo.Number(0) will be converted to 'False'
-    - Clingo.Number(1) will be converted to 'True'
-
-    For everything else the conversion fails
-    """
-    def cltopy(symbol) -> bool:
-        if symbol == 1:
-            return True
-        if symbol == 0:
-            return False
-        raise TypeError("value must be either '0' or '1'")
-
-    def pytocl(v):
-        if isinstance(v, bool):
-            return int(v)
-        raise TypeError("value is not a valid boolean")
-
-
-#------------------------------------------------------------------------------
 # refine_field is a function that creates a sub-class of a BaseField (or BaseField
 # sub-class). It restricts the set of allowable values based on a functor or an
 # explicit set of values.
@@ -2550,8 +2486,10 @@ def infer_field_definition(type_: Type[Any], module: str) -> Optional[Type[BaseF
         field = IntegerField if len(type_.__bases__) == 1 else infer_field_definition(type_.__bases__[0], module)
         return define_enum_field(field, type_)
     if issubclass(type_, bool):
+        from clorm.lib.boolean import BooleanField
         return BooleanField
     if issubclass(type_, StrictBool):
+        from clorm.lib.boolean import StrictBooleanField
         return StrictBooleanField
     if issubclass(type_, int):
         return IntegerField

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2528,6 +2528,8 @@ def infer_field_definition(type_: Type[Any], module: str) -> Optional[Type[BaseF
         # if type_ just inherits from Enum is IntegerField, otherwise find appropriate Field
         field = IntegerField if len(type_.__bases__) == 1 else infer_field_definition(type_.__bases__[0], module)
         return define_enum_field(field, type_)
+    if issubclass(type_, bool):
+        return BooleanField
     if issubclass(type_, int):
         return IntegerField
     if issubclass(type_, str):

--- a/clorm/orm/types.py
+++ b/clorm/orm/types.py
@@ -6,6 +6,7 @@ __all__ = [
     "ConstantStr",
     "HeadList",
     "HeadListReversed",
+    "StrictBool",
     "TailList",
     "TailListReversed",
 ]
@@ -32,4 +33,13 @@ else:
     class TailList(Generic[_T]):
         pass
     class TailListReversed(Generic[_T]):
+        pass
+
+if TYPE_CHECKING:
+    StrictBool = bool
+else:
+    class StrictBool(int):
+        """
+        StrictBool to allow for bools which are not type-coerced.
+        """
         pass

--- a/tests/test_libboolean.py
+++ b/tests/test_libboolean.py
@@ -1,0 +1,49 @@
+#------------------------------------------------------------------------------
+# Unit tests for the bool library
+#------------------------------------------------------------------------------
+
+
+import unittest
+
+from clorm.lib.boolean import BooleanField, StrictBooleanField
+from clorm.orm.noclingo import Number, String
+from tests.support import check_errmsg
+
+
+class LibBoolTestCase(unittest.TestCase):
+
+
+    #--------------------------------------------------------------------------
+    # Make sure BooleanField does what we expect
+    #--------------------------------------------------------------------------
+    def test_booleanfield(self):
+        symstr = Number(0)
+        self.assertEqual(type(BooleanField.cltopy(symstr)), bool)
+        self.assertEqual(BooleanField.cltopy(symstr), False)
+        self.assertEqual(BooleanField.pytocl(0), symstr)
+
+        symstr = String("false")
+        self.assertEqual(type(BooleanField.cltopy(symstr)), bool)
+        self.assertEqual(BooleanField.cltopy(symstr), False)
+
+        self.assertEqual(BooleanField.pytocl("false"), Number(0))
+        self.assertEqual(BooleanField.pytocl("TrUe"), Number(1))
+        self.assertEqual(BooleanField.pytocl("on"), Number(1))
+        self.assertEqual(BooleanField.pytocl("off"), Number(0))
+
+        with self.assertRaises(TypeError) as ctx:
+            BooleanField.cltopy(String("2"))
+        check_errmsg("value '2'",ctx)
+
+    #--------------------------------------------------------------------------
+    # Make sure StrictBooleanField does what we expect
+    #--------------------------------------------------------------------------
+    def test_strictbooleanfield(self):
+        symstr = Number(1)
+        self.assertEqual(type(StrictBooleanField.cltopy(symstr)), bool)
+        self.assertEqual(StrictBooleanField.cltopy(symstr), True)
+        self.assertEqual(StrictBooleanField.pytocl(True), symstr)
+
+        with self.assertRaises(TypeError) as ctx:
+            StrictBooleanField.cltopy(Number(2))
+        check_errmsg("value must be either",ctx)

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -31,7 +31,7 @@ from clorm import ( BaseField, Raw, RawField, IntegerField, StringField,
                     HeadList, HeadListReversed, TailList, TailListReversed )
 
 # Implementation imports
-from clorm.orm.core import ( dealiased_path, field, get_field_definition,
+from clorm.orm.core import ( BooleanField, dealiased_path, field, get_field_definition,
                              PredicatePath, QCondition, trueall, notcontains )
 
 import clingo
@@ -103,6 +103,20 @@ class FieldTestCase(unittest.TestCase):
         self.assertEqual(RawField.pytocl(Raw(symstr)), symstr)
         self.assertEqual(RawField.pytocl(symstr), symstr)
 
+        symstr = Number(0)
+        self.assertEqual(type(BooleanField.cltopy(symstr)), bool)
+        self.assertEqual(BooleanField.cltopy(symstr), False)
+        self.assertEqual(BooleanField.pytocl(0), symstr)
+
+        symstr = String("false")
+        self.assertEqual(type(BooleanField.cltopy(symstr)), bool)
+        self.assertEqual(BooleanField.cltopy(symstr), False)
+
+        self.assertEqual(BooleanField.pytocl("false"), Number(0))
+        self.assertEqual(BooleanField.pytocl("TrUe"), Number(1))
+        self.assertEqual(BooleanField.pytocl("on"), Number(1))
+        self.assertEqual(BooleanField.pytocl("off"), Number(0))
+
         # Now some bad conversions
         with self.assertRaises(TypeError) as ctx:
             x=StringField.cltopy(Number(1))
@@ -115,6 +129,10 @@ class FieldTestCase(unittest.TestCase):
         with self.assertRaises(TypeError) as ctx:
             x=ConstantField.cltopy(Function("x",[Number(1)]))
         check_errmsg("Symbol 'x(1)'",ctx)
+
+        with self.assertRaises(TypeError) as ctx:
+            x=BooleanField.cltopy(String("2"))
+        check_errmsg("value '2'",ctx)
 
     #--------------------------------------------------------------------------
     # Test that the simple field unify functions work as expected for clingo

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -9,6 +9,7 @@
 # ------------------------------------------------------------------------------
 
 import inspect
+import sys
 from typing import Tuple, Union
 import unittest
 import datetime
@@ -1549,6 +1550,28 @@ class PredicateTestCase(unittest.TestCase):
         with self.subTest("raw symbol annotations"):
             p10 = P10(Raw(Function("test",[String("1")])))
             self.assertEqual(str(p10), "p10(test(\"1\"))")
+
+        with self. subTest("bool variable"):
+            class P11(Predicate):
+                a: bool
+
+            p11 = P11(True)
+            self.assertEqual(str(p11), "p11(1)")
+        
+
+    @unittest.skipIf(sys.version_info < (3,7), "because of Union simplification in < 3.7")
+    def test_predicate_annotated_fields_union_bool_int(self):
+            class P(Predicate):
+                a: Union[bool, int]
+
+            p = P(True)
+            self.assertEqual(str(p), "p(1)")
+            p = P(2)
+            self.assertEqual(str(p), "p(2)")
+            p = P._unify(Function("p",[String("off")]))
+            self.assertEqual(p.a, False)
+            p = P._unify(Function("p",[Number(-1)]))
+            self.assertEqual(p.a, -1)
 
     def test_predicate_with_wrong_mixed_annotations_and_Fields(self):
         with self.assertRaises(TypeError, msg="order of fields can't be determined"):

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -32,7 +32,7 @@ from clorm import ( BaseField, Raw, RawField, IntegerField, StringField,
                     HeadList, HeadListReversed, TailList, TailListReversed )
 
 # Implementation imports
-from clorm.orm.core import ( BooleanField, StrictBooleanField, dealiased_path, field, get_field_definition,
+from clorm.orm.core import ( dealiased_path, field, get_field_definition,
                              PredicatePath, QCondition, trueall, notcontains )
 
 import clingo
@@ -104,25 +104,6 @@ class FieldTestCase(unittest.TestCase):
         self.assertEqual(RawField.pytocl(Raw(symstr)), symstr)
         self.assertEqual(RawField.pytocl(symstr), symstr)
 
-        symstr = Number(0)
-        self.assertEqual(type(BooleanField.cltopy(symstr)), bool)
-        self.assertEqual(BooleanField.cltopy(symstr), False)
-        self.assertEqual(BooleanField.pytocl(0), symstr)
-
-        symstr = String("false")
-        self.assertEqual(type(BooleanField.cltopy(symstr)), bool)
-        self.assertEqual(BooleanField.cltopy(symstr), False)
-
-        self.assertEqual(BooleanField.pytocl("false"), Number(0))
-        self.assertEqual(BooleanField.pytocl("TrUe"), Number(1))
-        self.assertEqual(BooleanField.pytocl("on"), Number(1))
-        self.assertEqual(BooleanField.pytocl("off"), Number(0))
-
-        symstr = Number(1)
-        self.assertEqual(type(StrictBooleanField.cltopy(symstr)), bool)
-        self.assertEqual(StrictBooleanField.cltopy(symstr), True)
-        self.assertEqual(StrictBooleanField.pytocl(True), symstr)
-
         # Now some bad conversions
         with self.assertRaises(TypeError) as ctx:
             x=StringField.cltopy(Number(1))
@@ -135,14 +116,6 @@ class FieldTestCase(unittest.TestCase):
         with self.assertRaises(TypeError) as ctx:
             x=ConstantField.cltopy(Function("x",[Number(1)]))
         check_errmsg("Symbol 'x(1)'",ctx)
-
-        with self.assertRaises(TypeError) as ctx:
-            x=BooleanField.cltopy(String("2"))
-        check_errmsg("value '2'",ctx)
-
-        with self.assertRaises(TypeError) as ctx:
-            x=StrictBooleanField.cltopy(Number(2))
-        check_errmsg("value must be either",ctx)
 
     #--------------------------------------------------------------------------
     # Test that the simple field unify functions work as expected for clingo


### PR DESCRIPTION
This PR adds support for `bool` to be used as a type annotation when defining a predicate class

```python
class T(Predicate):
    a: bool
    b: StrictBool
    c: Union[bool, int]
```
To convert from/to `bool` the following lookups will be used (strings converted to lower case)
```python
BOOL_FALSE = {0, '0', 'off', 'f', 'false', 'n', 'no'}
BOOL_TRUE = {1, '1', 'on', 't', 'true', 'y', 'yes'}
```
If `StrictBool` is used, just integers `0` and `1` are allowed

In Python < 3.7 `Union[bool,int]` is simplified to `int`, so if you can't upgrade you can use the more stricter version `Union[StrictBool, int]` instead.

Also keep in mind when defining `Union` annotations, it's recommended to include the most specific type first and followed by less specific types 
