### PR TITLE
Improve performance of unification process

### DIFF
--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2328,6 +2328,7 @@ def _generate_dynamic_predicate_functions(class_name: str, namespace: Dict):
              "AnySymbol": AnySymbol,
              "Type": Type,
              "Optional" : Optional,
+             "List": List,
              "_P": _P}
 
     for f in pdefn:
@@ -2805,7 +2806,10 @@ class Predicate(object, metaclass=_PredicateMeta):
 
     if typing.TYPE_CHECKING:
         @classmethod
-        def _unify(cls: Type[_P], raw: AnySymbol) -> Optional[_P]:
+        def _unify(cls: Type[_P],
+                   raw: AnySymbol,
+                   raw_args: Optional[List[AnySymbol]]=None,
+                   raw_name: Optional[str]=None) -> Optional[_P]:
             pass
 
     #--------------------------------------------------------------------------

--- a/clorm/orm/symbols_facts.py
+++ b/clorm/orm/symbols_facts.py
@@ -10,12 +10,13 @@
 # ------------------------------------------------------------------------------
 
 import itertools
-from typing import Any, Iterable, Union
+from typing import Iterable, Iterator, Optional, Union
 from collections import abc, defaultdict
 
 import clingo
 import clingo.ast as clast
 from .core import *
+from .core import AnySymbol
 from .noclingo import SymbolMode, SymbolType, Function, Number, String
 from .factbase import *
 from .core import get_field_definition, PredicatePath, kwargs_check_keys, \
@@ -77,24 +78,7 @@ class Unifier(object):
     def add_predicate(self,predicate):
         self._add_predicates([predicate])
 
-    def unify_symbol(self,sym,*,raise_nomatch=False):
-        known_names = set([name for _, name in self._pgroups.keys()])
-        sym_name = sym.name
-        if sym_name in known_names:
-            sym_args = sym.arguments
-            for pred in self._pgroups[(len(sym_args),sym_name)]:
-                instance = pred._unify(sym, sym_args, sym_name)
-                if instance is not None:
-                    return instance
-        if raise_nomatch:
-            raise UnifierNoMatchError(
-                f"Cannot unify symbol '{sym}' to predicates in {self._predicates}",
-                sym, self._predicates)
-        return None
-
-    def unify(self,symbols,*,factbase=None,raise_nomatch=False):
-        fb=FactBase() if factbase is None else factbase
-        facts = []
+    def iter_unify(self, symbols: Iterable[AnySymbol], raise_nomatch: bool) -> Iterator[Predicate]:
         known_names = set([name for _, name in self._pgroups.keys()])
         for sym in symbols:
             sym_name = sym.name
@@ -104,13 +88,19 @@ class Unifier(object):
                 for pred in self._pgroups[(len(sym_args),sym_name)]:
                     instance = pred._unify(sym, sym_args, sym_name)
                     if instance is not None:
-                        facts.append(instance)
+                        yield instance
                         break
             if raise_nomatch and instance is None:
                 raise UnifierNoMatchError(
                     f"Cannot unify symbol '{sym}' to predicates in {self._predicates}",
                     sym, self._predicates)
-        fb.add(facts)
+
+    def unify_symbol(self, sym: AnySymbol, *, raise_nomatch: bool=False) -> Optional[Predicate]:
+        return next(self.iter_unify([sym], raise_nomatch), None)
+
+    def unify(self, symbols: Iterable[AnySymbol], *, factbase: Optional[FactBase]=None, raise_nomatch: bool=False) -> FactBase:
+        fb=FactBase() if factbase is None else factbase
+        fb.add(list(self.iter_unify(symbols, raise_nomatch)))
         return fb
 
 #------------------------------------------------------------------------------
@@ -119,28 +109,7 @@ class Unifier(object):
 # ------------------------------------------------------------------------------
 
 def _unify(predicates, symbols):
-    # To make things a little more efficient use the arity-name signature as a
-    # filter. However, Python doesn't have a built in multidict class, and I
-    # don't want to add a dependency to an external library just for one small
-    # feature, so implement a simple structure here.
-    types = defaultdict(list)
-    for cls in predicates:
-        types[(len(cls.meta), cls.meta.name)].append(cls)
-    known_names = set([name for _, name in types.keys()])
-    
-    # Loop through symbols and yield when we have a match
-    for raw in symbols:
-        raw_name = raw.name
-        if raw_name not in known_names:
-            continue
-        raw_args = raw.arguments
-        classes = types[(len(raw_args), raw_name)]
-        if not classes: continue
-        for cls in classes:
-            f = cls._unify(raw, raw_args, raw_name)
-            if f is not None:
-                yield f
-                break
+    return Unifier(predicates).iter_unify(symbols, raise_nomatch=False) 
 
 
 #------------------------------------------------------------------------------

--- a/clorm/orm/symbols_facts.py
+++ b/clorm/orm/symbols_facts.py
@@ -93,9 +93,10 @@ class Unifier(object):
         fb=FactBase() if factbase is None else factbase
         for sym in symbols:
             matched = False
-            mpredicates = self._pgroups.get((len(sym.arguments),sym.name),[])
+            sym_args, sym_name = sym.arguments, sym.name
+            mpredicates = self._pgroups.get((len(sym_args),sym_name),[])
             for pred in mpredicates:
-                instance = pred._unify(sym)
+                instance = pred._unify(sym, sym_args, sym_name)
                 if instance is not None:
                     fb.add(instance)
                     matched = True
@@ -124,10 +125,11 @@ def _unify(predicates, symbols):
 
     # Loop through symbols and yield when we have a match
     for raw in symbols:
-        classes = types.get((len(raw.arguments), raw.name))
+        raw_args, raw_name = raw.arguments, raw.name
+        classes = types.get((len(raw_args), raw_name))
         if not classes: continue
         for cls in classes:
-            f = cls._unify(raw)
+            f = cls._unify(raw, raw_args, raw_name)
             if f is not None:
                 yield f
                 break

--- a/clorm/orm/templating.py
+++ b/clorm/orm/templating.py
@@ -72,15 +72,16 @@ def __init__(self,
                          self._sign)
 
 @classmethod
-def _unify(cls: Type[_P], raw: AnySymbol) -> Optional[_P]:
+def _unify(cls: Type[_P], raw: AnySymbol, raw_args: Optional[List[AnySymbol]]=None, raw_name: Optional[str]=None) -> Optional[_P]:
     try:
-        raw_args = raw.arguments
+        raw_args = raw_args if raw_args else raw.arguments
+        raw_name = raw_name if raw_name else raw.name
         if len(raw_args) != {pdefn.arity}:
             return None
 
         {{%sign_check_unify%}}
 
-        if raw.name != "{pdefn.name}":
+        if raw_name != "{pdefn.name}":
             return None
 
         instance = cls.__new__(cls)

--- a/tests/test_orm_symbols_facts.py
+++ b/tests/test_orm_symbols_facts.py
@@ -72,6 +72,7 @@ class UnifyTestCase(unittest.TestCase):
         self.assertTrue(Tmp._unify(rt2) is not None)
         t1 = Tmp(1,Raw(raw1))
         t2 = Tmp(1,Raw(raw2))
+        self.assertTrue(Tmp._unify(rt2, rt2.arguments, rt2.name) == t2)
 
         self.assertEqual(set([f for f in unify([Tmp], [rt1,rt2])]),set([t1,t2]))
         self.assertEqual(t1.r1.symbol, raw1)


### PR DESCRIPTION
This PR improves the performance of the unification process especially if not all Symbols (Facts, Predicates) should be unified

- Don't call `Symbol.arguments` if `Symbol.name` is unknown (not in list of predicates)
- Reuse `Symbol.arguments` and `Symbol.name` when calling `Predicate._unify`
- Remove duplicate code in `Unifier.unify`, `Unifier.unify_symbol` and `_unify`
