### PR TITLE
Support pep561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     license="MIT",
     url="https://github.com/potassco/clorm",
     packages=["clorm","clorm.orm","clorm.util","clorm.lib"],
+    package_data={"clorm": ["py.typed"]},
     install_requires=['clingo'] if sys.version_info >= (3, 8) else ['clingo', 'typing_extensions'],
     long_description=read("README.rst"),
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     url="https://github.com/potassco/clorm",
     packages=["clorm","clorm.orm","clorm.util","clorm.lib"],
     package_data={"clorm": ["py.typed"]},
+    zip_safe=False,  # https://mypy.readthedocs.io/en/latest/installed_packages.html
     install_requires=['clingo'] if sys.version_info >= (3, 8) else ['clingo', 'typing_extensions'],
     long_description=read("README.rst"),
 )


### PR DESCRIPTION
Add marker file `py.typed` to support [PEP561](https://peps.python.org/pep-0561/)