### PR TITLE
More type annotations

### DIFF
--- a/clorm/clingo.py
+++ b/clorm/clingo.py
@@ -10,7 +10,7 @@ for more details.
 
 import functools
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar, Iterable, List, Optional, Sequence, Tuple, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast, overload
 from .orm import *
 from .util.wrapper import init_wrapper, make_class_wrapper
 
@@ -42,9 +42,9 @@ __version__ = oclingo.__version__
 # Helper function to smartly build a unifier if only a list of predicates have
 # been provided.
 # ------------------------------------------------------------------------------
+_Unifier = Union[List[Type[Predicate]], SymbolPredicateUnifier]
 
-
-def _build_unifier(unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]]) -> Optional[SymbolPredicateUnifier]:
+def _build_unifier(unifier: Optional[_Unifier]) -> Optional[SymbolPredicateUnifier]:
     if unifier is None:
         return None
     if isinstance(unifier, SymbolPredicateUnifier):
@@ -80,7 +80,7 @@ class ModelOverride(object):
     if TYPE_CHECKING:
         _wrapped: OModel  # will be set through init_wrapper
 
-    def __init__(self, model: OModel, unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]] = None) -> None:
+    def __init__(self, model: OModel, unifier: Optional[_Unifier] = None) -> None:
         self._unifier = _build_unifier(unifier)
         _check_is_func(model, "symbols")
         init_wrapper(self, wrapped_=model)
@@ -182,7 +182,7 @@ class SolveHandleOverride(object):
     if TYPE_CHECKING:
         _wrapped: OSolveHandle  # will be set through init_wrapper
 
-    def __init__(self, handle: OSolveHandle, unifier: Optional[Union[List[Predicate], SymbolPredicateUnifier]] = None) -> None:
+    def __init__(self, handle: OSolveHandle, unifier: Optional[_Unifier] = None) -> None:
         init_wrapper(self, wrapped_=handle)
         self._unifier = _build_unifier(unifier)
 
@@ -200,14 +200,14 @@ class SolveHandleOverride(object):
 
     def __iter__(self):
         for model in self.solvehandle_:
-            yield Model(model, unifier=self._unifier)  # type: ignore
+            yield Model(model, unifier=self._unifier)
 
     def __enter__(self):
-        self.solvehandle_.__enter__()  # type: ignore
+        self.solvehandle_.__enter__()
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self.solvehandle_.__exit__(exception_type, exception_value, traceback)  # type: ignore
+        self.solvehandle_.__exit__(exception_type, exception_value, traceback)
         return None
 
 
@@ -344,7 +344,7 @@ class ControlOverride(object):
         return self._unifier
 
     @unifier.setter
-    def unifier(self, unifier: Union[List[Predicate], SymbolPredicateUnifier]) -> None:
+    def unifier(self, unifier: _Unifier) -> None:
         self._unifier = _build_unifier(unifier)
 
     # ------------------------------------------------------------------------------
@@ -472,7 +472,7 @@ class ControlOverride(object):
 
             @functools.wraps(on_model)
             def on_model_wrapper(model):
-                return on_model(Model(model, self.unifier))  # type: ignore
+                return on_model(Model(model, self.unifier))
             nkwargs["on_model"] = on_model_wrapper
 
         # Call the wrapped solve function and handle the return value

--- a/clorm/clingo.py
+++ b/clorm/clingo.py
@@ -33,15 +33,7 @@ if oclingo.__version__ >= "5.5.0":
 else:
     from clingo import parse_program  # type: ignore
 
-from clingo import ( core, Logger, MessageCode, TruthValue, version, symbol, Function, Infimum, 
-                     Number, String, Supremum, Symbol, SymbolType, Tuple_, parse_term,
-                     symbolic_atoms, SymbolicAtom, SymbolicAtoms, theory_atoms, TheoryAtom,
-                     TheoryElement, TheoryTerm, TheoryTermType, util, solving, ModelType,
-                     SolveControl, SolveResult, propagator, Assignment, PropagateControl,
-                     PropagateInit, Propagator, PropagatorCheckMode, Trail, backend, Backend,
-                     HeuristicType, Observer, configuration, Configuration, statistics,
-                     StatisticsArray, StatisticsMap, StatisticsValue, control,
-                     application, Application, ApplicationOptions, Flag, clingo_main)
+from clingo import *
 
 __all__ = list([k for k in oclingo.__dict__.keys() if k[0] != '_'])
 
@@ -166,7 +158,7 @@ class ModelOverride(object):
 
 
 if TYPE_CHECKING:
-    class Model(ModelOverride, OModel):
+    class Model(ModelOverride, OModel):  # type: ignore
         pass
 else:
     Model = make_class_wrapper(OModel, ModelOverride)
@@ -220,7 +212,7 @@ class SolveHandleOverride(object):
 
 
 if TYPE_CHECKING:
-    class SolveHandle(SolveHandleOverride, OSolveHandle):
+    class SolveHandle(SolveHandleOverride, OSolveHandle):  # type: ignore
         pass
 else:
     SolveHandle = make_class_wrapper(OSolveHandle, SolveHandleOverride)
@@ -481,7 +473,7 @@ class ControlOverride(object):
         result = self.control_.solve(**nkwargs)
         if ("yield_" in nkwargs and nkwargs["yield_"]) or \
            (async_keyword in nkwargs and nkwargs[async_keyword]):
-            return SolveHandle(cast(OSolveHandle, result), unifier=self._unifier)
+            return SolveHandle(cast(OSolveHandle, result), unifier=self._unifier)  # type: ignore
         else:
             return cast(oclingo.SolveResult, result)
 

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2700,6 +2700,8 @@ def _define_field_for_predicate(cls_meta: '_PredicateMeta') -> Type[BaseField]:
 #------------------------------------------------------------------------------
 @__dataclass_transform__(field_descriptors=(field,))
 class _PredicateMeta(type):
+    if TYPE_CHECKING:
+        meta: PredicateDefn
 
     #--------------------------------------------------------------------------
     # Allocate the new metaclass
@@ -2768,7 +2770,7 @@ class _PredicateMeta(type):
     def __getitem__(self, idx):
         return self.meta.path[idx]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[PredicatePath]:
         return iter([self[k] for k in self.meta.keys()])
 
 #------------------------------------------------------------------------------
@@ -2872,7 +2874,7 @@ class Predicate(object, metaclass=_PredicateMeta):
         return cls._field
 
     # Clone the object with some differences
-    def clone(self, **kwargs):
+    def clone(self: _P, **kwargs: Any) -> _P:
         """Clone the object with some differences.
 
         For any field name that is not one of the parameter keywords the clone
@@ -2915,12 +2917,12 @@ class Predicate(object, metaclass=_PredicateMeta):
     # Overloaded index operator to access the values and len operator
     #--------------------------------------------------------------------------
 
-    def __iter__(self) -> Iterator[PredicatePath]:
+    def __iter__(self) -> Iterator[Any]:
         # The number of parameters in a predicate are always small so convenient
         # to generate a list of values rather than have a specialised iterator.
         return iter([self[idx] for idx in range(0,len(self))])
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> Any:
         """Allows for index based access to field elements."""
         return self.meta[idx].__get__(self)
 

--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2351,7 +2351,7 @@ def _generate_dynamic_predicate_functions(class_name: str, namespace: Dict) -> N
              "AnySymbol": AnySymbol,
              "Type": Type,
              "Optional" : Optional,
-             "List": List,
+             "Sequence": Sequence,
              "_P": _P}
 
     for f in pdefn:
@@ -2843,7 +2843,7 @@ class Predicate(object, metaclass=_PredicateMeta):
         @classmethod
         def _unify(cls: Type[_P],
                    raw: AnySymbol,
-                   raw_args: Optional[List[AnySymbol]]=None,
+                   raw_args: Optional[Sequence[AnySymbol]]=None,
                    raw_name: Optional[str]=None) -> Optional[_P]:
             pass
 

--- a/clorm/orm/factbase.py
+++ b/clorm/orm/factbase.py
@@ -5,27 +5,22 @@
 
 import sys
 import io
-import operator
-import bisect
-import inspect
 import abc
-import functools
 import itertools
-from typing import Iterable, Union
+from typing import Callable, Iterable, Iterator, List, Optional, TextIO, Tuple, Type, Union
 
 from .core import *
-from .core import get_field_definition, PredicatePath, kwargs_check_keys, \
-    validate_root_paths
+from .core import PredicatePath, validate_root_paths
 from .core import PredicateDefn
 
 from .query import *
 
-from .query import Placeholder, OrderBy, desc, asc
+from .query import Placeholder, desc, asc
 
 from .query import process_where, process_join, process_orderby, \
     make_query_plan, QuerySpec, QueryExecutor
 
-from .factcontainers import FactSet, FactIndex, FactMap, factset_equality
+from .factcontainers import FactMap, factset_equality
 
 __all__ = [
     'FactBase',
@@ -36,6 +31,7 @@ __all__ = [
 #------------------------------------------------------------------------------
 # Global
 #------------------------------------------------------------------------------
+_Facts = Union[Iterable[Predicate], Callable[[], Iterable[Predicate]]]
 
 #------------------------------------------------------------------------------
 # Support function for printing ASP facts: Note: _trim_docstring() is taken from
@@ -97,7 +93,7 @@ def _format_docstring(docstring,output):
 def _maxwidth(lines):
     return max([len(l) for l in lines])
 
-def _format_commented(fm: FactMap, out):
+def _format_commented(fm: FactMap, out: TextIO) -> None:
     pm: PredicateDefn = fm.predicate.meta
     docstring = _trim_docstring(fm.predicate.__doc__) \
         if fm.predicate.__doc__ else ""
@@ -169,7 +165,7 @@ class FactBase(object):
     def _init(self, facts=None, indexes=None):
 
         # flag that initialisation has taken place
-        self._delayed_init = None
+        self._delayed_init: Optional[Callable[[], None]] = None
 
         # If it is delayed initialisation then get the facts
         if facts and callable(facts):
@@ -227,7 +223,7 @@ class FactBase(object):
     #--------------------------------------------------------------------------
     # Initiliser
     #--------------------------------------------------------------------------
-    def __init__(self, facts=None, indexes=None):
+    def __init__(self, facts: Optional[_Facts] = None, indexes: Optional[Iterable[PredicatePath]] = None) -> None:
         self._delayed_init=None
         if callable(facts):
             def delayed_init():
@@ -263,17 +259,17 @@ class FactBase(object):
         self._check_init()  # Check for delayed init
         return self._add(arg)
 
-    def remove(self, arg):
+    def remove(self, arg: Predicate) -> None:
         """Remove a fact from the fact base (raises an exception if no fact). """
         self._check_init()  # Check for delayed init
         return self._remove(arg, raise_on_missing=True)
 
-    def discard(self, arg):
+    def discard(self, arg: Predicate) -> None:
         """Remove a fact from the fact base. """
         self._check_init()  # Check for delayed init
         return self._remove(arg, raise_on_missing=False)
 
-    def pop(self):
+    def pop(self) -> Predicate:
         """Pop an element from the FactBase. """
         self._check_init()  # Check for delayed init
         for pt, fm in self._factmaps.items():
@@ -350,25 +346,25 @@ class FactBase(object):
         return QueryImpl(self._factmaps, qspec)
 
     @property
-    def predicates(self):
+    def predicates(self) -> Tuple[Type[Predicate], ...]:
         """Return the list of predicate types that this fact base contains."""
 
         self._check_init()  # Check for delayed init
         return tuple([pt for pt, fm in self._factmaps.items() if fm])
 
     @property
-    def indexes(self):
+    def indexes(self) -> Tuple[PredicatePath, ...]:
         self._check_init()  # Check for delayed init
         return self._indexes
 
-    def facts(self):
+    def facts(self) -> List[Predicate]:
         """Return all facts."""
 
         self._check_init()  # Check for delayed init
         tmp = [ fm.factset for fm in self._factmaps.values() if fm]
         return list(itertools.chain(*tmp))
 
-    def asp_str(self,*,width=0,commented=False,sorted=False):
+    def asp_str(self, *, width: int = 0, commented: bool = False, sorted: bool = False) -> str:
         """Return a ASP string representation of the fact base.
 
         The generated ASP string representation is syntactically correct ASP
@@ -418,9 +414,7 @@ class FactBase(object):
         out.close()
         return data
 
-
-
-    def __str__(self):
+    def __str__(self) -> str:
         self._check_init()  # Check for delayed init
         tmp = ", ".join([str(f) for f in self])
         return '{' + tmp + '}'
@@ -455,7 +449,7 @@ class FactBase(object):
         self._check_init() # Check for delayed init
         return sum([len(fm.factset) for fm in self._factmaps.values()])
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Predicate]:
         self._check_init() # Check for delayed init
 
         for fm in self._factmaps.values():
@@ -569,60 +563,60 @@ class FactBase(object):
     #--------------------------------------------------------------------------
     # Set functions
     #--------------------------------------------------------------------------
-    def union(self,*others):
+    def union(self, *others: _Facts) -> 'FactBase':
         """Implements the set union() function"""
-        others=[o if isinstance(o, self.__class__) else FactBase(o) for o in others]
+        factbases = [o if isinstance(o, self.__class__) else FactBase(o) for o in others]
         self._check_init() # Check for delayed init
-        for o in others: o._check_init()
+        for fb in factbases: fb._check_init()
 
-        fb=FactBase()
+        fb = FactBase()
         predicates = set(self._factmaps.keys())
-        for o in others: predicates.update(o._factmaps.keys())
+        for o in factbases: predicates.update(o._factmaps.keys())
 
         for p in predicates:
-            pothers=[ o._factmaps[p] for o in others if p in o._factmaps]
+            pothers = [o._factmaps[p] for o in factbases if p in o._factmaps]
             if p in self._factmaps:
                 fb._factmaps[p] = self._factmaps[p].union(*pothers)
             else:
                 fb._factmaps[p] = FactMap(p).union(*pothers)
         return fb
 
-    def intersection(self,*others):
+    def intersection(self, *others: _Facts) -> 'FactBase':
         """Implements the set intersection() function"""
-        others=[o if isinstance(o, self.__class__) else FactBase(o) for o in others]
+        factbases = [o if isinstance(o, self.__class__) else FactBase(o) for o in others]
         self._check_init() # Check for delayed init
-        for o in others: o._check_init()
+        for fb in factbases: fb._check_init()
 
-        fb=FactBase()
+        fb = FactBase()
         predicates = set(self._factmaps.keys())
-        for o in others: predicates.intersection_update(o._factmaps.keys())
+        for fb_ in factbases: predicates.intersection_update(fb_._factmaps.keys())
 
         for p in predicates:
-            pothers=[ o._factmaps[p] for o in others if p in o._factmaps]
+            pothers = [o._factmaps[p] for o in factbases if p in o._factmaps]
             fb._factmaps[p] = self._factmaps[p].intersection(*pothers)
         return fb
 
-    def difference(self,*others):
+    def difference(self, *others: _Facts) -> 'FactBase':
         """Implements the set difference() function"""
-        others=[o if isinstance(o, self.__class__) else FactBase(o) for o in others]
+        factbases = [o if isinstance(o, self.__class__) else FactBase(o) for o in others]
         self._check_init() # Check for delayed init
-        for o in others: o._check_init()
+        for fb in factbases: fb._check_init()
 
-        fb=FactBase()
+        fb = FactBase()
         predicates = set(self._factmaps.keys())
 
         for p in predicates:
-            pothers=[ o._factmaps[p] for o in others if p in o._factmaps]
+            pothers = [o._factmaps[p] for o in factbases if p in o._factmaps]
             fb._factmaps[p] = self._factmaps[p].difference(*pothers)
         return fb
 
-    def symmetric_difference(self,other):
+    def symmetric_difference(self, other: _Facts) -> 'FactBase':
         """Implements the set symmetric_difference() function"""
         if not isinstance(other, self.__class__): other=FactBase(other)
         self._check_init() # Check for delayed init
         other._check_init()
 
-        fb=FactBase()
+        fb = FactBase()
         predicates = set(self._factmaps.keys())
         predicates.update(other._factmaps.keys())
 
@@ -637,44 +631,43 @@ class FactBase(object):
 
         return fb
 
-    def update(self,*others):
+    def update(self, *others: _Facts) -> None:
         """Implements the set update() function"""
-        others=[o if isinstance(o, self.__class__) else FactBase(o) for o in others]
+        factbases = [o if isinstance(o, self.__class__) else FactBase(o) for o in others]
         self._check_init() # Check for delayed init
-        for o in others: o._check_init()
+        for fb in factbases: fb._check_init()
 
-        for o in others:
-            for p,fm in o._factmaps.items():
+        for fb in factbases:
+            for p,fm in fb._factmaps.items():
                 if p in self._factmaps: self._factmaps[p].update(fm)
                 else: self._factmaps[p] = fm.copy()
 
-    def intersection_update(self,*others):
+    def intersection_update(self, *others: _Facts) -> None:
         """Implements the set intersection_update() function"""
-        others=[o if isinstance(o, self.__class__) else FactBase(o) for o in others]
+        factbases = [o if isinstance(o, self.__class__) else FactBase(o) for o in others]
         self._check_init() # Check for delayed init
-        for o in others: o._check_init()
-        num = len(others)
+        for fb in factbases: fb._check_init()
 
         predicates = set(self._factmaps.keys())
-        for o in others: predicates.intersection_update(o._factmaps.keys())
+        for fb in factbases: predicates.intersection_update(fb._factmaps.keys())
         pred_to_delete = set(self._factmaps.keys()) - predicates
 
         for p in pred_to_delete: self._factmaps[p].clear()
         for p in predicates:
-            pothers=[ o._factmaps[p] for o in others if p in o._factmaps]
+            pothers = [o._factmaps[p] for o in factbases if p in o._factmaps]
             self._factmaps[p].intersection_update(*pothers)
 
-    def difference_update(self,*others):
+    def difference_update(self, *others: _Facts) -> None:
         """Implements the set difference_update() function"""
-        others=[o if isinstance(o, self.__class__) else FactBase(o) for o in others]
+        factbases = [o if isinstance(o, self.__class__) else FactBase(o) for o in others]
         self._check_init() # Check for delayed init
-        for o in others: o._check_init()
+        for fb in factbases: fb._check_init()
 
         for p in self._factmaps.keys():
-            pothers=[ o._factmaps[p] for o in others if p in o._factmaps ]
+            pothers = [o._factmaps[p] for o in factbases if p in o._factmaps]
             self._factmaps[p].difference_update(*pothers)
 
-    def symmetric_difference_update(self,other):
+    def symmetric_difference_update(self, other: _Facts) -> None:
         """Implements the set symmetric_difference_update() function"""
         if not isinstance(other, self.__class__): other=FactBase(other)
         self._check_init() # Check for delayed init
@@ -689,12 +682,11 @@ class FactBase(object):
             else:
                 if p in other._factmaps: self._factmaps[p] = other._factmaps[p].copy()
 
-
-    def copy(self):
+    def copy(self) -> 'FactBase':
         """Implements the set copy() function"""
         self._check_init() # Check for delayed init
-        fb=FactBase()
-        for p,fm in self._factmaps.items():
+        fb = FactBase()
+        for p, _ in self._factmaps.items():
             fb._factmaps[p] = self._factmaps[p].copy()
         return fb
 

--- a/clorm/orm/factbase.py
+++ b/clorm/orm/factbase.py
@@ -7,7 +7,7 @@ import sys
 import io
 import abc
 import itertools
-from typing import Callable, Iterable, Iterator, List, Optional, TextIO, Tuple, Type, Union
+from typing import Callable, Iterable, Iterator, List, Optional, TextIO, Tuple, Type, Union, cast
 
 from .core import *
 from .core import PredicatePath, validate_root_paths
@@ -101,11 +101,11 @@ def _format_commented(fm: FactMap, out: TextIO) -> None:
     if pm.arity == 0:
         lines = [ "Unary predicate signature:", indent + pm.name ]
     else:
-        def build_signature(p: Predicate) -> str:
+        def build_signature(p: Type[Predicate]) -> str:
             args = []
             for pp in p:
                 complex = pp.meta.field.complex
-                args.append(pp._pathseq[1] if not complex else build_signature(complex))
+                args.append(cast(str, pp._pathseq[1]) if not complex else build_signature(complex))
             return f"{p.meta.name}({','.join(args)})"
 
         lines = [ "Predicate signature:",

--- a/clorm/orm/factbase.py
+++ b/clorm/orm/factbase.py
@@ -205,12 +205,12 @@ class FactBase(object):
             raise TypeError(f"'{arg}' is not a Predicate instance")
 
         sorted_facts = sorted(arg, key=lambda x: x.__class__.__name__)
-        for ptype, grouped_facts in itertools.groupby(sorted_facts, lambda x: x.__class__):
-            if not issubclass(ptype, Predicate):
+        for type_, grouped_facts in itertools.groupby(sorted_facts, lambda x: x.__class__):
+            if not issubclass(type_, Predicate):
                 raise TypeError(f"{list(grouped_facts)} are not Predicate instances")
-            if not ptype in self._factmaps:
-                self._factmaps[ptype] = FactMap(ptype)
-            self._factmaps[ptype].add_facts(grouped_facts)
+            if not type_ in self._factmaps:
+                self._factmaps[type_] = FactMap(type_)
+            self._factmaps[type_].add_facts(grouped_facts)
         return
 
     def _remove(self, fact, raise_on_missing):

--- a/clorm/orm/factcontainers.py
+++ b/clorm/orm/factcontainers.py
@@ -3,19 +3,14 @@
 # FactMap.
 # ------------------------------------------------------------------------------
 
-import io
 import operator
 import collections
 import bisect
-import inspect
-import abc
-import functools
 import itertools
-from typing import Type
+from typing import Any, Iterable, List, Type
 
 from .core import *
-from .core import notcontains, PredicatePath, \
-    get_field_definition, kwargs_check_keys
+from .core import notcontains, PredicatePath
 
 # ------------------------------------------------------------------------------
 # In order to implement FactBase I originally used the built in 'set'
@@ -265,7 +260,7 @@ def _fm_iterable(other):
     else: return other
 
 class FactMap(object):
-    def __init__(self, ptype: Type[Predicate], indexes=[]):
+    def __init__(self, ptype: Type[Predicate], indexes: Iterable[Any]=[]) -> None:
         def clean_path(p):
             p = path(p)
             if hashable_path(p) != hashable_path(p.meta.dealiased):
@@ -282,11 +277,10 @@ class FactMap(object):
         self._ptype = ptype
         self._factset = FactSet()
         self._path2factindex = collections.OrderedDict()
-        self._factindexes = []
 
         # Validate the paths to be indexed
         allindexes = set([clean_path(p) for p in indexes])
-
+        factindexes: List[FactIndex] = []
         for pth in allindexes:
             tmppath=path(pth)
             if hashable_path(tmppath.meta.dealiased) != hashable_path(tmppath):
@@ -297,8 +291,8 @@ class FactMap(object):
                                   "'{}'").format(tmppath, path(ptype)))
             tmpfi = FactIndex(tmppath)
             self._path2factindex[hashable_path(tmppath)] = tmpfi
-            self._factindexes.append(tmpfi)
-        self._factindexes = tuple(self._factindexes)
+            factindexes.append(tmpfi)
+        self._factindexes = tuple(factindexes)
 
     def add_facts(self, facts):
         for f in facts:
@@ -329,7 +323,7 @@ class FactMap(object):
         for fi in self._factindexes: fi.clear()
 
     @property
-    def predicate(self) -> Predicate:
+    def predicate(self) -> Type[Predicate]:
         return self._ptype
 
     @property

--- a/clorm/orm/factcontainers.py
+++ b/clorm/orm/factcontainers.py
@@ -11,6 +11,7 @@ import inspect
 import abc
 import functools
 import itertools
+from typing import Type
 
 from .core import *
 from .core import notcontains, PredicatePath, \
@@ -264,7 +265,7 @@ def _fm_iterable(other):
     else: return other
 
 class FactMap(object):
-    def __init__(self, ptype: Predicate, indexes=[]):
+    def __init__(self, ptype: Type[Predicate], indexes=[]):
         def clean_path(p):
             p = path(p)
             if hashable_path(p) != hashable_path(p.meta.dealiased):

--- a/clorm/orm/noclingo.py
+++ b/clorm/orm/noclingo.py
@@ -140,7 +140,8 @@ class NoSymbol(object):
             self._value = int(value)
             self._hash = hash(self._value)
         elif stype == SymbolType.String:
-            _ = value.encode()
+            if not isinstance(value, str):
+                raise TypeError("{value} is not a str")
             self._value = value
             self._hash = hash(self._value)
         elif stype == SymbolType.Function:
@@ -241,7 +242,7 @@ class NoSymbol(object):
             return True
         if self.positive and other.negative:
             return False
-        return self.arguments > tuple(other.arguments)
+        return self.arguments > tuple(clingo_to_noclingo(arg) for arg in other.arguments)
 
     def __le__(self, other: object) -> bool:
         """Overloaded boolean operator."""
@@ -268,7 +269,7 @@ class NoSymbol(object):
             return False
         if self.positive and other.negative:
             return True
-        return self.arguments < tuple(other.arguments)
+        return self.arguments < tuple(clingo_to_noclingo(arg) for arg in other.arguments)
 
     def __ge__(self, other: object) -> bool:
         """Overloaded boolean operator."""
@@ -335,7 +336,7 @@ NoSupremum = NoSymbol(SymbolType.Supremum)
 # Functions to convert between clingo.Symbol and noclingo.Symbol
 # --------------------------------------------------------------------------------
 
-def clingo_to_noclingo(clsym: Symbol) -> NoSymbol:
+def clingo_to_noclingo(clsym: AnySymbol) -> NoSymbol:
     if isinstance(clsym, NoSymbol):
         return clsym
     if clsym.type == clingo.SymbolType.Infimum:
@@ -355,7 +356,7 @@ def clingo_to_noclingo(clsym: Symbol) -> NoSymbol:
                       clsym.positive)
 
 
-def noclingo_to_clingo(nclsym: NoSymbol) -> Symbol:
+def noclingo_to_clingo(nclsym: AnySymbol) -> Symbol:
     if isinstance(nclsym, clingo.Symbol):
         return nclsym
     if nclsym.type == SymbolType.Infimum:

--- a/clorm/orm/templating.py
+++ b/clorm/orm/templating.py
@@ -5,14 +5,13 @@ an `exec()` call. This file contains some template code snippets and functions
 to help apply these templates.
 
 """
-from typing import Dict
 
 # ------------------------------------------------------------------------------
 # Helper functions for PredicateMeta class to create a Predicate
 # class constructor.
 # ------------------------------------------------------------------------------
 
-def expand_template(template: str, **kwargs: Dict[str, str]):
+def expand_template(template: str, **kwargs: str) -> str:
     """Expand the template by substituting the arguments.
 
     If the argument contains multiple lines then extra spaces are added to each

--- a/clorm/orm/templating.py
+++ b/clorm/orm/templating.py
@@ -71,7 +71,7 @@ def __init__(self,
                          self._sign)
 
 @classmethod
-def _unify(cls: Type[_P], raw: AnySymbol, raw_args: Optional[List[AnySymbol]]=None, raw_name: Optional[str]=None) -> Optional[_P]:
+def _unify(cls: Type[_P], raw: AnySymbol, raw_args: Optional[Sequence[AnySymbol]]=None, raw_name: Optional[str]=None) -> Optional[_P]:
     try:
         raw_args = raw_args if raw_args else raw.arguments
         raw_name = raw_name if raw_name else raw.name

--- a/clorm/util/wrapper.py
+++ b/clorm/util/wrapper.py
@@ -26,7 +26,7 @@ import functools
 import inspect
 from typing import Any, Optional, Type, TypeVar, Union, overload
 
-_T = TypeVar("_T", bound=object)
+_T = TypeVar("_T", bound=type)
 
 # ------------------------------------------------------------------------------
 # Make proxy member functions and properties
@@ -114,10 +114,10 @@ def make_class_wrapper(inputclass: Type[object]) -> Type[object]: ...
 
 
 @overload
-def make_class_wrapper(inputclass: Type[object], override: Type[_T]) -> Type[_T]: ...
+def make_class_wrapper(inputclass: Type[object], override: _T) -> _T: ...
 
 
-def make_class_wrapper(inputclass: Type[object], override: Optional[Type[_T]] = None) -> Type[Union[object, _T]]:
+def make_class_wrapper(inputclass: Type[object], override: Optional[_T] = None) -> Union[Type[object], _T]:
     def getattrdoc(cls, key):
         if not cls: return None
         try:

--- a/tests/test_orm_atsyntax.py
+++ b/tests/test_orm_atsyntax.py
@@ -45,7 +45,7 @@ __all__ = [
 class TypeCastSignatureTestCase(unittest.TestCase):
     def setUp(self):
         class DateField(StringField):
-            pytocl = lambda dt: dt.strftime("%Y%m%d")
+            pytocl = lambda dt: datetime.datetime.strftime(dt,"%Y%m%d")
             cltopy = lambda s: datetime.datetime.strptime(s,"%Y%m%d").date()
 
         class DowField(ConstantField):

--- a/tests/test_orm_factbase.py
+++ b/tests/test_orm_factbase.py
@@ -1545,7 +1545,7 @@ class QueryAPI2TestCase(unittest.TestCase):
     #--------------------------------------------------------------------------
     #   Improve error message for bad join statement
     #--------------------------------------------------------------------------
-    def test_api_complex_query_join_ordered(self):
+    def test_api_bad_join_statement(self):
         F = self.F
         G = self.G
         fb = self.factbase

--- a/tests/test_orm_query.py
+++ b/tests/test_orm_query.py
@@ -1803,12 +1803,12 @@ class QueryPlanTestCase(unittest.TestCase):
         joins = pj([F.anum == G.anum, F.anum < GA.anum, cross(G,FA)],[F,G,FA,GA])
         qspec = QuerySpec(roots=[F,G,FA,GA],join=joins,where=[],order_by=[])
         qorder = oppref_join_order([], qspec)
-        self.assertEqual(qorder,[FA,GA,G,F])
+        self.assertEqual(qorder,[F,G,GA,FA])
 
     # ------------------------------------------------------------------------------
     # Test the basic heuristic for generating the join order
     # ------------------------------------------------------------------------------
-    def test_nonapi_oppref_join_order(self):
+    def test_nonapi_basic_join_order(self):
         F = path(self.F)
         G = path(self.G)
         FA = alias(F)


### PR DESCRIPTION
This PR adds type annotations to most of the 'public' functions and methods (see #62)
It also fixes some mypy issues when unpacking a fact or use clorm's Control, Model or SolveHandle classes.

The query-API is not annotated with types. Theoretically it would be possible to add type annotations by using `TypeVarTuple`, `Generic` and some clever tricks to infer also the correct type when using joins, but there is a technical limitation which makes this not possible to use with py36 (see [here](https://github.com/python/typing/pull/963))
