### PR TITLE
Bugfix: Enum was  ignored when used in combination with ConstantStr

### DIFF
--- a/clorm/orm/core.py
+++ b/clorm/orm/core.py
@@ -2515,12 +2515,12 @@ def infer_field_definition(type_: Type[Any], module: str) -> Optional[Type[BaseF
         # not just return a tuple of Fields, but create a Field-Instance and take the type so
         # Tuple[...] can be used within Union
         return type(get_field_definition(tuple(infer_field_definition(arg, module) for arg in args), module))
-    if issubclass(type_, ConstantStr):
-        return ConstantField
     if issubclass(type_, enum.Enum):
         # if type_ just inherits from Enum is IntegerField, otherwise find appropriate Field
         field = IntegerField if len(type_.__bases__) == 1 else infer_field_definition(type_.__bases__[0], module)
         return define_enum_field(field, type_) if field else None
+    if issubclass(type_, ConstantStr):
+        return ConstantField
     if issubclass(type_, bool):
         from clorm.lib.boolean import BooleanField
         return BooleanField
@@ -2826,7 +2826,7 @@ class Predicate(object, metaclass=_PredicateMeta):
     if typing.TYPE_CHECKING:
         # populated by the metaclass, defined here to help IDEs only
         _meta: typing.ClassVar[PredicateDefn]
-        _field: typing.ClassVar[BaseField]
+        _field: typing.ClassVar[Type[BaseField]]
 
     #--------------------------------------------------------------------------
     #
@@ -2871,7 +2871,7 @@ class Predicate(object, metaclass=_PredicateMeta):
 
     @_classproperty
     @classmethod
-    def Field(cls) -> BaseField:
+    def Field(cls) -> Type[BaseField]:
         """A BaseField sub-class corresponding to a Field for this class."""
         return cls._field
 

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1481,6 +1481,10 @@ class PredicateTestCase(unittest.TestCase):
             self.assertTrue(isinstance(P5.d.meta.field, IntegerField))
             self.assertEqual(str(p5), "p5(\"a\",1,c,42)")
 
+        with self.subTest("check that field for EnumConstStr is created correctly"):
+            self.assertTrue(P5.c.meta.field.__class__ is not ConstantField)
+            self.assertEqual(str(P5.c.meta.field), "ConstantField_Restriction(index=False)")
+
         class P6(Predicate):
             a: Tuple[int,...]
         class P61(Predicate):


### PR DESCRIPTION
Let's consider the following situation
```python
class Status(ConstantStr, enum.Enum):
    ON  = "on"
    OFF = "off"
    
 class Robot(Predicate):
     name: str
     status: Status
```
Because of a wrong priority (order) when trying to infer (create) the correct Field,  `Robot.status` was handled as a `ConstantField` instead of a custom `Field` which restricts the allowed values. The result was that you could create a Robot-fact with status f.i. "standby"

This PR fixes that problem by first handling the case if the type of `Status` is an Enum and handle the case for a `ConstantStr` afterwards