### PR TITLE
More deterministic behavior when creating the query plan

### DIFF
--- a/clorm/orm/query.py
+++ b/clorm/orm/query.py
@@ -14,14 +14,12 @@ import inspect
 import enum
 from typing import Any, Generator, List, Set
 
-from clorm.util.oset import OrderedSet
-
-from ..util import OrderedSet as FactSet
+from ..util import OrderedSet
 from ..util.tools import all_equal
 from .core import *
 from .core import get_field_definition, QCondition, PredicatePath, \
     validate_root_paths, kwargs_check_keys, trueall, falseall, notcontains
-from .factcontainers import FactSet, FactIndex, FactMap
+from .factcontainers import FactIndex, FactMap
 
 __all__ = [
     'Query',
@@ -2520,7 +2518,7 @@ class InQuerySorter(object):
 # ------------------------------------------------------------------------------
 
 def make_first_prejoin_query(jqp, factsets, factindexes):
-    factset = factsets.get(jqp.root.meta.predicate, FactSet())
+    factset = factsets.get(jqp.root.meta.predicate, OrderedSet())
 
     pjk = jqp.prejoin_key_clause
     prejcb = jqp.prejoin_clauses
@@ -2598,7 +2596,7 @@ def make_prejoin_query_source(jqp, factsets, factindexes):
     pjob = jqp.prejoin_orderbys
     jk   = jqp.join_key
     predicate = jqp.root.meta.predicate
-    factset = factsets.get(jqp.root.meta.predicate, FactSet())
+    factset = factsets.get(jqp.root.meta.predicate, OrderedSet())
 
     # If there is a prejoin key clause then every comparator within it must
     # refer to exactly one index

--- a/clorm/orm/query.py
+++ b/clorm/orm/query.py
@@ -12,7 +12,9 @@ import functools
 import itertools
 import inspect
 import enum
-from typing import Any, Generator
+from typing import Any, Generator, List, Set
+
+from clorm.util.oset import OrderedSet
 
 from ..util import OrderedSet as FactSet
 from ..util.tools import all_equal
@@ -2348,8 +2350,8 @@ def make_query_plan_preordered_roots(indexed_paths, root_join_order,
     whereclauses = qspec.where
     orderbys = qspec.order_by
 
-    joinset=set(joins)
-    clauseset=set(whereclauses)
+    joinset=OrderedSet(joins)
+    clauseset=OrderedSet(whereclauses)
     visited=set({})
     orderbys=list(orderbys)
 
@@ -2362,12 +2364,11 @@ def make_query_plan_preordered_roots(indexed_paths, root_join_order,
     # For a set of visited root paths and a set of comparator
     # statements return the subset of join statements that only reference paths
     # that have been visited.  Removes these joins from the original set.
-    def visitedsubset(visited, inset):
-        outlist=[]
-        for comp in inset:
-            if visited.issuperset([hashable_path(r) for r in comp.roots]):
-                outlist.append(comp)
-        for comp in outlist: inset.remove(comp)
+    def visitedsubset(visited: Set, inset: OrderedSet) -> List:
+        outlist=[comp for comp in inset if visited.issuperset(map(hashable_path, comp.roots))]
+
+        for comp in outlist:
+            inset.remove(comp)
         return outlist
 
 


### PR DESCRIPTION
should partially resolve #86 

Instead of a default `set` we use an `OrderedSet` to get a deterministic behavior when iterating over the sets to find the rootpath joins and clauses for each query sub plan.