### PR TITLE
update deploy scripts

### DIFF
--- a/.github/ppa-wip/build.sh
+++ b/.github/ppa-wip/build.sh
@@ -75,7 +75,7 @@ EOF
                 cd "${rep}"
                 pdebuild --buildresult .. --auto-debsign --debsign-k 744d959e10f5ad73f9cf17cc1d150536980033d5 -- --basetgz /var/cache/pbuilder/${ref}-${rep}.tgz --source-only-changes
                 sed -i '/\.buildinfo$/d' ../python3-clorm_${VERSION}_source.changes
-                debsign --no-re-sign -k744d959e10f5ad73f9cf17cc1d150536980033d5 ../python3-clorm_${VERSION}_source.changes
+                debsign --re-sign -k744d959e10f5ad73f9cf17cc1d150536980033d5 ../python3-clorm_${VERSION}_source.changes
             )
             ;;
         put)

--- a/.github/workflows/conda-dev.yml
+++ b/.github/workflows/conda-dev.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/pipsource.yml
+++ b/.github/workflows/pipsource.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/ppa-dev.yml
+++ b/.github/workflows/ppa-dev.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get install pbuilder pbuilder-scripts debootstrap devscripts dh-make dput dh-python python3-all
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 


### PR DESCRIPTION
This updates the deploy scripts and should fix your build issues. Hope the master branch is the right place. Otherwise, feel free to retarget.

You can also update the deploy scripts yourself:

```bash
cd <CLORM_REP>/.github
python <DEPLOY_REP>/deploy.py
```

The deploy repository is private in the potassco organization.

