### PR TITLE
Extend the forward reference handling to more complex boundary cases

### DIFF
--- a/clorm/orm/_typing.py
+++ b/clorm/orm/_typing.py
@@ -1,5 +1,5 @@
-import sys
 import inspect
+import sys
 from inspect import FrameInfo
 from typing import Any, Dict, ForwardRef, Optional, Tuple, Type, TypeVar, Union, _eval_type, cast
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 clingo>=5.5.1
-typing_extensions; python_version < '3.8'
+typing_extensions; python_version < '3.11'
 dataclasses; python_version == '3.6'

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -164,7 +164,6 @@ XP1, XP2 = define_predicates()
             p2 = module.XP2(a=p1)
             self.assertEqual(str(p2), 'p2(p1(c,3,"42"))')
 
-
     def test_forward_ref(self):
         def module_():
             from typing import ForwardRef

--- a/tests/test_mypy_query.py
+++ b/tests/test_mypy_query.py
@@ -1,6 +1,10 @@
+import sys
 from typing import Tuple
 
-from typing_extensions import reveal_type
+if sys.version_info < (3, 11):
+    from typing_extensions import reveal_type
+else:
+    from typing import reveal_type
 
 from clorm import FactBase, Predicate
 from clorm.orm._queryimpl import GroupedQuery, UnGroupedQuery

--- a/tests/test_orm_core.py
+++ b/tests/test_orm_core.py
@@ -1489,7 +1489,7 @@ class PredicateTestCase(unittest.TestCase):
     def test_predicates_with_annotated_fields(self):
         class P(Predicate):
             a: int = IntegerField
-            b = StringField
+            b: str = StringField
 
         class P1(Predicate):
             a: int


### PR DESCRIPTION
I've extended the postponed type annotations for some more complicated (boundary) cases. For example, when the Predicate definition with type annotation is defined in a non-global scope (eg. within a function) and is referring to another predicate definition of a different scope. While some of these cases are probably not something anyone would (or should) do, it is good to have it working in case.

@florianfischer91 let me know if you have any thoughts. I find this postponed annotations and the `from __future__ import annotations` stuff to be quite a mess. It seems that there is no clear way to deal with it that doesn't involve some sort of hack; such as accessing undocumented APIs (eg. typing._eval_type()) or complicated workarounds for specific versions of Python.  